### PR TITLE
Sanitize table name for postgresql

### DIFF
--- a/src/leiningen/new/luminus/dbs/postgres_db.clj
+++ b/src/leiningen/new/luminus/dbs/postgres_db.clj
@@ -3,7 +3,7 @@
 
 (def db 
   {:subprotocol "postgresql"
-   :subname "//localhost/{{name}}"
+   :subname "//localhost/{{sanitized}}"
    :user "admin"
    :password "admin"})
 


### PR DESCRIPTION
Acording to document of postgresql[1](http://www.postgresql.org/docs/current/interactive/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS), table name must be sanitized.
