### PR TITLE
In repl/start-server, ring server join option should be ":join?" not ":join"

### DIFF
--- a/src/leiningen/new/luminus/repl.clj
+++ b/src/leiningen/new/luminus/repl.clj
@@ -1,4 +1,4 @@
-(ns {{name}}.repl    
+(ns {{name}}.repl
   (:use {{name}}.handler
         ring.server.standalone
         [ring.middleware file-info file]))
@@ -21,12 +21,12 @@
   [& [port]]
   (let [port (if port (Integer/parseInt port) 8080)]
     (reset! server
-            (serve (get-handler) 
+            (serve (get-handler)
                    {:port port 
                     :init init
                     :auto-reload? true
                     :destroy destroy 
-                    :join true}))
+                    :join? false}))
     (println "Server started on port [" port "].")
     (println (str "You can view the site at http://localhost:" port))))
 


### PR DESCRIPTION
Very minor issue: repl/start-server call to ring serve uses :join true as an option. This is ignored as the option is :join?. start-server currently works as expected since the default is :join? false. 
