### PR TITLE
Fix conflict between +bootstrap and +site features.

### DIFF
--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -89,7 +89,10 @@
             [["src/{{sanitized}}/views/layout.clj" (*render* "site/layout.clj")]
              ["src/{{sanitized}}/routes/auth.clj"  (*render* "site/auth.clj")]
              ["src/{{sanitized}}/handler.clj"      (*render* "site/handler.clj")]]
-            (if-not (some #{"+bootstrap"} @features) (add-feature :+bootstrap))
+            (if-not (some #{"+bootstrap"} @features)
+              (do
+                (swap! features conj "+bootstrap")
+                (add-feature :+bootstrap)))
             (if-not (some #{"+h2" "+postgres"} @features)
               (do
                 (swap! features conj "+h2")

--- a/src/leiningen/new/luminus/site/layout.clj
+++ b/src/leiningen/new/luminus/site/layout.clj
@@ -32,11 +32,7 @@
 (defhtml base [& content]
   [:head
    [:title "Welcome to {{name}}"]
-   (include-css "/css/bootstrap.min.css"
-                "/css/bootstrap-responsive.min.css"
-                "/css/screen.css")
-   (include-js "//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"
-               "/js/bootstrap.min.js")]
+   (include-css "/css/screen.css")]
   [:body content])
 
 (defn common [& content]


### PR DESCRIPTION
When I generate a luminus project with `lein new luminus NAME +site` everything works fine,
but when I use `lein new luminus NAME +bootstrap +site`  (let's imagine user don't know that `+site` feature will add boostrap automatically) I get css, js duplications in my `layout.clj`:

```
(defhtml
  base
  [& content]
  [:head
   [:title "Welcome to meteor"]
   (include-css
     "/css/bootstrap.min.css"
     "/css/bootstrap-responsive.min.css"
     "/css/bootstrap.min.css"
     "/css/bootstrap-responsive.min.css"
     "/css/screen.css")
   (include-js
     "//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"
     "/js/bootstrap.min.js"
     "//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"
     "/js/bootstrap.min.js")]
  [:body content])
```

As I understand it happend, because `site/layout.clj` already has these dependencies https://github.com/yogthos/luminus-template/blob/master/src/leiningen/new/luminus/site/layout.clj#L32 and extra dependencies was added by `post_process :+bootstrap`.

To fix this behaviour I've removed dependencies from `site/layout.clj` and added "+bootstrap" to the `features` atom in the `add-feature :+site` method. Looks like it should work in both cases now, when features are used together or separately. 

If it sounds right, you could merge it.
