### PR TITLE
Improve site layout.

### DIFF
--- a/src/leiningen/new/luminus/layout.clj
+++ b/src/leiningen/new/luminus/layout.clj
@@ -14,10 +14,11 @@
   [:footer "Copyright &copy; ..."])
 
 (defhtml base [& content]
-  [:head
-   [:title "Welcome to {{name}}"]
-   (include-css "/css/screen.css")]
-  [:body content])
+  (html5
+   [:head
+    [:title "Welcome to {{name}}"]
+    (include-css "/css/screen.css")]
+   [:body content]))
 
 (defn common [& content]
   (base

--- a/src/leiningen/new/luminus/site/auth.clj
+++ b/src/leiningen/new/luminus/site/auth.clj
@@ -34,7 +34,7 @@
              (vali/on-error :pass1 error-item)
              [:p (password-field {:tabindex 3} "pass1")]
 
-             (submit-button {:tabindex 4} "create account"))))
+             (submit-button {:class "btn" :tabindex 4} "create account"))))
 
 (defn handle-registration [id pass pass1]
   (if (valid? id pass pass1)

--- a/src/leiningen/new/luminus/site/layout.clj
+++ b/src/leiningen/new/luminus/site/layout.clj
@@ -7,33 +7,39 @@
 
 (defn login-menu []
   (if (session/get :user)
-    (form-to [:post "/logout"]
+    (form-to {:class "navbar-form"} [:post "/logout"]
              (submit-button "logout"))
 
-    (form-to [:post "/login"]
-             (text-field {:placeholder "user id"} "id")
-             (password-field {:placeholder "password"} "pass")
-             (submit-button "login"))))
+    (form-to {:class "navbar-form"} [:post "/login"]
+             (text-field {:class "span2"
+                          :style "margin-right: 5px"
+                          :placeholder "user id"} "id")
+             (password-field {:class "span2"
+                              :style "margin-right: 5px"
+                              :placeholder "password"} "pass")
+             (submit-button {:class "btn"} "Login"))))
 
 (defn header []
   [:div.navbar.navbar-fixed-top.navbar-inverse
-     [:div.navbar-inner
-      [:div.container
-       [:ul.nav
-        [:li (link-to "/" "Home")]
-        [:li (link-to "/about" "About")]
-        [:li (login-menu)]
-        [:li (if-not (session/get :user)
-               (link-to "/register" "register"))]]]]])
+   [:div.navbar-inner
+    [:div.container
+     [:ul.nav
+      [:li (link-to "/" "Home")]
+      [:li (link-to "/about" "About")]]
+     [:ul.nav.pull-right
+      [:li (login-menu)]
+      [:li (if-not (session/get :user)
+             (link-to "/register" "Register"))]]]]])
 
 (defn footer []
   [:footer "Copyright &copy; ..."])
 
 (defhtml base [& content]
-  [:head
-   [:title "Welcome to {{name}}"]
-   (include-css "/css/screen.css")]
-  [:body content])
+  (html5
+   [:head
+    [:title "Welcome to {{name}}"]
+    (include-css "/css/screen.css")]
+   [:body content]))
 
 (defn common [& content]
   (base


### PR DESCRIPTION
text-fields were thin, because DOCTYPE hasn't been setted up. 
![before](https://dl.dropbox.com/u/2428018/Screenshots/0f.png) 
![before](https://dl.dropbox.com/u/2428018/Screenshots/0c.png) 

I've added html 5 doctype with `html5` calls and minor style improvements. ![now](https://dl.dropbox.com/u/2428018/Screenshots/0e.png)
