### PR TITLE
Fix replacement of separator chars on Windows

### DIFF
--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -2,7 +2,8 @@
   (:use [leiningen.new.dependency-injector]
         [leiningen.new.templates :only [renderer sanitize year ->files]]
         [leinjacker.utils :only [lein-generation]])
-  (:import java.io.File))
+  (:import java.io.File
+           java.util.regex.Matcher))
 
 (declare ^{:dynamic true} *name*)
 (declare ^{:dynamic true} *render*)
@@ -26,7 +27,7 @@
 (defmethod post-process :+bootstrap [_ project-file]
   (add-to-layout (.replaceAll
                   (str *name* "/src/" (sanitize *name*) "/views/layout.clj")
-                         "/" File/separator)
+                         "/" (Matcher/quoteReplacement File/separator))
                  ["/css/bootstrap.min.css"
                   "/css/bootstrap-responsive.min.css"]
                  ["//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"


### PR DESCRIPTION
Backslashes are special when used in a replacement string. 
See the documentation of java.util.regex.Matcher.replaceAll(String) for details.
java.util.regex.Matcher.quoteReplacement(String) fixes backslashes so
they can be replaced verbatim.
