### PR TITLE
Fix broken project.clj

### DIFF
--- a/src/leiningen/new/dependency_injector.clj
+++ b/src/leiningen/new/dependency_injector.clj
@@ -109,7 +109,7 @@
 
 (defn set-lein-version [filename version]
   (spit filename
-        (let [project-str (slurp filename)
+        (let [project-str (.trim (slurp filename))
               length      (dec (count project-str))]
           (str (.substring project-str 0 (dec length))
                "\n  :min-lein-version \"" version "\")"))))


### PR DESCRIPTION
Slurping the project.clj file may result in a string with trailing white space (at least if I use nearly all features, that is `lein new luminus luminus-test +bootstrap +cljs +h2 +korma +site`).
This leads to a broken structure when inserting ":min-lein-version" before the 
last character. Trimming the string ensures that the last character is indeed the closing parenthesis.
