### PR TITLE
Fix bug with db/initialized?.

### DIFF
--- a/src/leiningen/new/luminus/dbs/h2_db.clj
+++ b/src/leiningen/new/luminus/dbs/h2_db.clj
@@ -16,7 +16,7 @@
 (defn initialized?
   "checks to see if the database schema is present"
   []
-  (.exists (new java.io.File (str (io/resource-path) db-store))))
+  (.exists (new java.io.File (str (io/resource-path) db-store ".h2.db"))))
 
 (defn create-users-table
   "creates the users table, the user has following fields


### PR DESCRIPTION
```
Exception in thread "main" org.h2.jdbc.JdbcBatchUpdateException: Table "USERS" already exists; SQL statement:
CREATE TABLE users (id varchar(20) PRIMARY KEY, first_name varchar(30), last_name varchar(30), email varchar(30), admin boolean, last_login time, is_active boolean, pass varchar(100)) [42101-170]
```

it happend on the second start of a project, when database file wasn't found because of wrong name.

```
$ ls
css              img              js               md               site.db.h2.db    site.db.trace.db
```
