### PR TITLE
Use trampoline in Procfile to conserve memory

### DIFF
--- a/src/leiningen/new/luminus/Procfile
+++ b/src/leiningen/new/luminus/Procfile
@@ -1,1 +1,1 @@
-web: lein with-profile production ring server
+web: lein with-profile production trampoline ring server


### PR DESCRIPTION
I deployed a new app using Luminus to Heroku and my logs were full of memory warnings:

```
2013-03-11T04:49:22+00:00 heroku[web.1]: Process running mem=522M(102.0%)
2013-03-11T04:49:22+00:00 heroku[web.1]: Error R14 (Memory quota exceeded)
```

[Heroku's Clojure documentation](https://devcenter.heroku.com/articles/clojure-support) suggests using the trampoline task. Once I applied it, I stopped getting memory warnings.
