### PR TITLE
For +site, h2 lookup of existing user :pass fails as map keyword is :PASS

### DIFF
--- a/src/leiningen/new/luminus/dbs/h2_schema.clj
+++ b/src/leiningen/new/luminus/dbs/h2_schema.clj
@@ -9,7 +9,7 @@
               :subname (str (io/resource-path) db-store)
               :user "sa"
               :password ""
-              :naming {:keys clojure.string/upper-case
+              :naming {:keys clojure.string/lower-case
                        :fields clojure.string/upper-case}})
 (defn initialized?
   "checks to see if the database schema is present"


### PR DESCRIPTION
views/auth.clj lookup of :pass for existing user fails as the db lookup map key is :PASS.
Changed h2 db-spec to use :naming :keys clojure.string/lower-case.

This works ok for +site sample, not sure if there is a downside for other apps.
