### PR TITLE
Remove redundant destroy function.

### DIFF
--- a/src/leiningen/new/luminus/handler.clj
+++ b/src/leiningen/new/luminus/handler.clj
@@ -10,9 +10,6 @@
   (route/resources "/")
   (route/not-found "Not Found"))
 
-(defn destroy []
-  (timbre/info "picture-gallery is shutting down"))
-
 (defn init
   "init will be called once when
    app is deployed as a servlet on


### PR DESCRIPTION
No need for it. It's defined below `init`.
