### PR TITLE
Update button class to btn-lg for Bootstrap 3

### DIFF
--- a/src/leiningen/new/luminus/templates/home.html
+++ b/src/leiningen/new/luminus/templates/home.html
@@ -3,7 +3,7 @@
  <div class="jumbotron">
     <h1>Welcome to {{name}}</h1>
     <p>Time to start building your site!</p>
-    <p><a class="btn btn-primary btn-large" href="http://luminusweb.net">Learn more &raquo;</a></p>
+    <p><a class="btn btn-primary btn-lg" href="http://luminusweb.net">Learn more &raquo;</a></p>
  </div>
 
  <div class="row-fluid">


### PR DESCRIPTION
Bootstrap 3 uses a CSS class called .btn-lg, not .btn-large. This appears to have been overlooked in the upgrade to Bootstrap 3. As a result, the button in the template app is normal sized. This PR restores it to large size.
