### PR TITLE
Enable connection pool by default for H2 db

### DIFF
--- a/src/leiningen/new/luminus/dbs/h2_schema.clj
+++ b/src/leiningen/new/luminus/dbs/h2_schema.clj
@@ -9,6 +9,7 @@
               :subname (str (io/resource-path) db-store)
               :user "sa"
               :password ""
+              :make-pool? true
               :naming {:keys clojure.string/lower-case
                        :fields clojure.string/upper-case}})
 (defn initialized?


### PR DESCRIPTION
I encountered great difficulty reading data out of a CLOB field. 

Attempts to access the `JdbcClob` object, results in the following error:

```
JdbcSQLException The object is already closed [90007-174]
```

Enabling `:make-pool? true` would be a sensible default.

For more information about the issue: https://github.com/korma/Korma/issues/200
