### PR TITLE
Works with --to-dir option of lein-new.

### DIFF
--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -1,8 +1,9 @@
 (ns leiningen.new.luminus
   (:use leiningen.new.dependency-injector
         leiningen.new.template-parser
-        [leiningen.new.templates :only [renderer sanitize year ->files]]
-        [leinjacker.utils :only [lein-generation]])
+        [leiningen.new.templates :only [renderer sanitize year ->files *dir*]]
+        [leinjacker.utils :only [lein-generation]]
+        [clojure.java.io :only [file]])
   (:import java.io.File
            java.util.regex.Matcher))
 
@@ -12,12 +13,12 @@
 
 (defn sanitized-path [& path]
   (.replaceAll
-   (str *name* "/src/" (sanitize *name*) (apply str path))
+   (str *dir* "/src/" (sanitize *name*) (apply str path))
    "/" (Matcher/quoteReplacement File/separator)))
 
 (defn sanitized-resource-path [& path]
   (.replaceAll
-   (str *name* "/resources/" (apply str path))
+   (str *dir* "/resources/" (apply str path))
    "/" (Matcher/quoteReplacement File/separator)))
 
 (defn add-sql-files [schema-file]
@@ -110,7 +111,7 @@
 (defmethod post-process :+mongodb [_ project-file]
   (add-mongo-dependencies project-file
                           ['com.novemberain/monger "1.7.0"])
-  (let [docs-filename (str *name* "/resources/public/md/docs.md")]
+  (let [docs-filename (str *dir* "/resources/public/md/docs.md")]
     (spit docs-filename (str (*render* "dbs/mongo_instructions.html") (slurp docs-filename)))))
 
 (defmethod add-feature :+migrations [_]
@@ -132,7 +133,7 @@
                (str "jdbc:" (if postgres? "postgresql" "mysql")
                   "://localhost" (if postgres? "/" ":3306/") (sanitize *name*)
                   "?user=db_user_name_here&password=db_user_password_here"))})
-  (let [docs-filename (str *name* "/resources/public/md/docs.md")]
+  (let [docs-filename (str *dir* "/resources/public/md/docs.md")]
     (spit docs-filename (str (*render* "dbs/db_instructions.html") (slurp docs-filename)))))
 
 (defmethod add-feature :+http-kit [_]
@@ -202,7 +203,7 @@
   (mapcat add-feature @features))
 
 (defn inject-dependencies []
-  (let [project-file (str *name* File/separator "project.clj")]
+  (let [project-file (file *dir* "project.clj")]
 
     (doseq [feature @features]
       (post-process feature project-file))


### PR DESCRIPTION
When --to-dir option of lein-new is used, the hypothesis that _name_
matches the last segment of --to-dir path does not hold.
Neither holds the hypothesis that the current directory is the parent
directory of the newly created project.

This is solved by using leiningen.new.templates/_dir_ dynamic var
which is set by lein-newnew to the real project folder.
