### PR TITLE
fix bug: @server in core.clj should be defonce to avoid being overwritten during compilation

### DIFF
--- a/src/leiningen/new/luminus/core.clj
+++ b/src/leiningen/new/luminus/core.clj
@@ -6,7 +6,7 @@
     [taoensso.timbre :as timbre])
   (:gen-class))
 
-(def server
+(defonce server
   "contains function that can be used to stop http-kit server"
   (atom nil))
 


### PR DESCRIPTION
fix bug: @server in core.clj should be defonce to avoid being overwritten during compilation
