### PR TITLE
Fix postgres dependency

### DIFF
--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -112,7 +112,7 @@
 
 (defmethod post-process :+postgres [_ project-file]
   (add-sql-dependencies project-file
-                        ['postgresql/postgresql "9.3-1102-jdbc41"]))
+                        ['org.postgresql/postgresql "9.3-1102-jdbc41"]))
 
 (defmethod add-feature :+mysql [_]
   (add-sql-files ["src/{{sanitized}}/db/schema.clj" (*render* "dbs/mysql_schema.clj")]))


### PR DESCRIPTION
I was getting this error when starting a new project with +postgres

```
(Could not find artifact postgresql:postgresql:jar:9.3-1102-jdbc41 in central (http://repo1.maven.org/maven2/))
(Could not find artifact postgresql:postgresql:jar:9.3-1102-jdbc41 in clojars (https://clojars.org/repo/))
```

When the postgres dependency was updated from 9.1-901-1.jdbc4 to 9.3-1102-jdbc41 the group id also needed to be changed to org.postgresql

See http://search.maven.org/#artifactdetails%7Cpostgresql%7Cpostgresql%7C9.1-901-1.jdbc4%7Cjar
vs http://search.maven.org/#artifactdetails%7Corg.postgresql%7Cpostgresql%7C9.3-1102-jdbc41%7Cjar
