### PR TITLE
fixes postgresql 9.3-1102.jdbc41 dependency error

### DIFF
--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -112,7 +112,7 @@
 
 (defmethod post-process :+postgres [_ project-file]
   (add-sql-dependencies project-file
-                        ['org.postgresql/postgresql "9.3-1102-jdbc41"]))
+                        ['org.postgresql/postgresql "9.3-1102.jdbc41"]))
 
 (defmethod add-feature :+mysql [_]
   (add-sql-files ["src/{{sanitized}}/db/schema.clj" (*render* "dbs/mysql_schema.clj")]))


### PR DESCRIPTION
Should read "9.3-1102.jdbc41" instead of "9.3-1102-jdbc41"
