### PR TITLE
Switch expected/actual in placeholder test

### DIFF
--- a/src/leiningen/new/luminus/handler_test.clj
+++ b/src/leiningen/new/luminus/handler_test.clj
@@ -6,8 +6,8 @@
 (deftest test-app
   (testing "main route"
     (let [response (app (request :get "/"))]
-      (is (= (:status response) 200))))
+      (is (= 200 (:status response)))))
 
   (testing "not-found route"
     (let [response (app (request :get "/invalid"))]
-      (is (= (:status response) 404)))))
+      (is (= 404 (:status response))))))


### PR DESCRIPTION
clojure.test assumes the expected parameter is the first one, while the
actual is the second

A small change, but it was confusing for a beginner like me to see the test output from Clojure reversed when I forced the test to fail.
