### PR TITLE
Set Selmer's resource path to 'templates'

### DIFF
--- a/src/leiningen/new/luminus/layout.clj
+++ b/src/leiningen/new/luminus/layout.clj
@@ -5,7 +5,7 @@
             [compojure.response :refer [Renderable]]
             [environ.core :refer [env]]))
 
-(def template-path "templates/")
+(parser/set-resource-path!  (clojure.java.io/resource "templates"))
 
 (deftype RenderableTemplate [template params]
   Renderable
@@ -21,7 +21,7 @@
                     ;; .getContextPath might not exist
                     (try (.getContextPath context)
                          (catch IllegalArgumentException _ context))))
-        (parser/render-file (str template-path template))
+        (parser/render-file (str template))
         response)
       "text/html; charset=utf-8")))
 

--- a/src/leiningen/new/luminus/templates/about.html
+++ b/src/leiningen/new/luminus/templates/about.html
@@ -1,4 +1,4 @@
-{% extends "templates/base.html" %}
+{% extends "base.html" %}
 {% block content %}
   <p>this is the story of {{name}}... work in progress</p>
 {% endblock %}

--- a/src/leiningen/new/luminus/templates/home.html
+++ b/src/leiningen/new/luminus/templates/home.html
@@ -1,4 +1,4 @@
-{% extends "templates/base.html" %}
+{% extends "base.html" %}
 {% block content %}
   <div class="jumbotron">
     <h1>Welcome to {{name}}</h1>


### PR DESCRIPTION
This change makes template paths consistent. Without it, when one extends a template one needs to prepend "templates/" to the path whereas when one defines routes one doesn't have to.
