### PR TITLE
Adding log-request code to docs.md

### DIFF
--- a/src/leiningen/new/luminus/core/resources/docs.md
+++ b/src/leiningen/new/luminus/core/resources/docs.md
@@ -3,7 +3,14 @@
 ### Managing Your Middleware
 
 Request middleware functions are located under the `<<name>>.middleware` namespace.
-A request logging helper called `log-request` has already been defined for you there.
+A request logging helper called `log-request` is defined below:
+
+```clojure
+(defn log-request [handler]
+  (fn [req]
+    (timbre/debug req)
+    (handler req)))
+```
 
 This namespace also defines two vectors for organizing the middleware called `development-middleware` and `production-middleware`.
 Any middleware that you only wish to run in development mode, such as `log-request`, should be added to the first vector.


### PR DESCRIPTION
Adding the log-request to the docs since it was removed from the middleware file on 941944b3bbfccef11cd33840b189821500594699