### PR TITLE
Minor formatting of sql queries template

### DIFF
--- a/src/leiningen/new/luminus/db/sql/queries.sql
+++ b/src/leiningen/new/luminus/db/sql/queries.sql
@@ -1,16 +1,16 @@
---name: create-user!
+-- name: create-user!
 -- creates a new user record
 INSERT INTO users
 (id, first_name, last_name, email, pass)
 VALUES (:id, :first_name, :last_name, :email, :pass)
 
---name: update-user!
+-- name: update-user!
 -- update an existing user record
 UPDATE users
 SET first_name = :first_name, last_name = :last_name, email = :email
 WHERE id = :id
 
 -- name: get-user
--- retrieve a used given the id.
+-- retrieve a user given the id.
 SELECT * FROM users
 WHERE id = :id


### PR DESCRIPTION
Normalized the 'name:' spacing and fixed a typo in get-user docstring.