### PR TITLE
Replacing ring's native in-memory session storage

### DIFF
--- a/src/leiningen/new/luminus/core/project.clj
+++ b/src/leiningen/new/luminus/core/project.clj
@@ -12,7 +12,7 @@
                  [compojure "1.4.0"]
                  [ring-webjars "0.1.1"]
                  [ring/ring-defaults "0.1.5"]
-                 [ring/ring-session-timeout "0.1.0"]
+                 [ring-ttl-session "0.1.0"]
                  [ring "1.4.0"
                   :exclusions [ring/ring-jetty-adapter]]
                  [metosin/ring-middleware-format "0.6.0"]

--- a/src/leiningen/new/luminus/core/src/handler.clj
+++ b/src/leiningen/new/luminus/core/src/handler.clj
@@ -2,8 +2,7 @@
   (:require [compojure.core :refer [defroutes routes wrap-routes]]
             [<<project-ns>>.routes.home :refer [home-routes]]<% if service-required %>
             <<service-required>><% endif %>
-            [<<project-ns>>.middleware :as middleware]
-            [<<project-ns>>.session :as session]<% if relational-db %>
+            [<<project-ns>>.middleware :as middleware]<% if relational-db %>
             [<<project-ns>>.db.core :as db]<% endif %>
             [compojure.route :as route]
             [taoensso.timbre :as timbre]
@@ -59,8 +58,6 @@
   (if (env :dev) (parser/cache-off!))
   (start-nrepl)<% if relational-db %>
   (db/connect!)<% endif %>
-  ;;start the expired session cleanup job
-  (session/start-cleanup-job!)
   (timbre/info (str
                  "\n-=[<<name>> started successfully"
                  (when (env :dev) " using the development profile")

--- a/src/leiningen/new/luminus/core/src/middleware.clj
+++ b/src/leiningen/new/luminus/core/src/middleware.clj
@@ -11,8 +11,6 @@
             [ring.middleware.webjars :refer [wrap-webjars]]
             [ring.middleware.defaults :refer [site-defaults wrap-defaults]]
             [ring.middleware.anti-forgery :refer [wrap-anti-forgery]]
-            [ring.middleware.session-timeout :refer [wrap-idle-session-timeout]]
-            [ring.middleware.session.memory :refer [memory-store]]
             [ring.middleware.format :refer [wrap-restful-format]]<% if service-middleware-required %>
             <<service-middleware-required>><% endif %><% if auth-middleware-required %>
             <<auth-middleware-required>><% endif %>))
@@ -75,14 +73,11 @@
   (-> handler
       wrap-dev<% if auth-middleware-required %>
       wrap-auth<% endif %>
-      (wrap-idle-session-timeout
-        {:timeout (* 60 30)
-         :timeout-response (redirect "/")})
       wrap-formats
       (wrap-defaults
         (-> site-defaults
             (assoc-in [:security :anti-forgery] false)
-            (assoc-in  [:session :store] (memory-store session/mem))))
+            (assoc-in  [:session :store] session/ttl-mem)))
       wrap-webjars
       wrap-servlet-context
       wrap-internal-error))

--- a/src/leiningen/new/luminus/core/src/session.clj
+++ b/src/leiningen/new/luminus/core/src/session.clj
@@ -1,20 +1,6 @@
-(ns <<project-ns>>.session)
+(ns <<project-ns>>.session
+  (:require [ring-ttl-session.core :refer [ttl-memory-store]]))
 
-(defonce mem (atom {}))
-(def half-hour 1800000)
-
-(defn- current-time []
-  (quot (System/currentTimeMillis) 1000))
-
-(defn- expired? [[id session]]
-  (pos? (- (:ring.middleware.session-timeout/idle-timeout session) (current-time))))
-
-(defn clear-expired-sessions []
-  (clojure.core/swap! mem #(->> % (filter expired?) (into {}))))
-
-(defn start-cleanup-job! []
-  (future
-    (loop []
-      (clear-expired-sessions)
-      (Thread/sleep half-hour)
-      (recur))))
+(defonce ttl-mem 
+  "Session storage whose keys expire in 30 minutes."
+  (ttl-memory-store (* 60 30)))


### PR DESCRIPTION
* The new storage has a TTL based on core.cache ([project's page](https://github.com/boechat107/ring-ttl-session)).
* Downside: there is no automatic redirect for expired sessions.