### PR TITLE
Replace deprecated js callback key

### DIFF
--- a/src/leiningen/new/luminus/cljs/env/dev/cljs/app.cljs
+++ b/src/leiningen/new/luminus/cljs/env/dev/cljs/app.cljs
@@ -6,6 +6,6 @@
 
 (figwheel/watch-and-reload
   :websocket-url "ws://localhost:3449/figwheel-ws"
-  :jsload-callback core/mount-components)
+  :on-jsload core/mount-components)
 
 (core/init!)


### PR DESCRIPTION
`:jsload-callback` seems deprecated, so I just replaced it :)

https://github.com/bhauman/lein-figwheel/blob/2e1733c4a728ed74051a860be844db4580dc0177/support/src/figwheel/client.cljs#L278-L283

