### PR TITLE
fixes to the default cljs navbar

### DIFF
--- a/src/leiningen/new/luminus/cljs/src/cljs/core.cljs
+++ b/src/leiningen/new/luminus/cljs/src/cljs/core.cljs
@@ -9,24 +9,29 @@
   (:import goog.History))
 
 (defn navbar []
-  [:nav.navbar.navbar-inverse.navbar-fixed-top
-   [:div.container
-    [:div.navbar-header
-     [:button.navbar-toggle.collapsed {:data-toggle   "collapse"
-                                       :data-target   "#my-navbar"
-                                       :aria-expanded "false"
-                                       :aria-controls "navbar"}
-      [:span.sr-only "Toggle Navigation"]
-      [:span.icon-bar]
-      [:span.icon-bar]
-      [:span.icon-bar]]
-     [:a.navbar-brand {:href "#/"} "myapp"]]
-    [:div#my-navbar.navbar-collapse.collapse
-     [:ul.nav.navbar-nav
-      [:li {:class (when (= :home (session/get :page)) "active")}
-       [:a {:href "#/"} "Home"]]
-      [:li {:class (when (= :about (session/get :page)) "active")}
-       [:a {:href "#/about"} "About"]]]]]])
+  (let [collapsed? (atom false)]
+    (fn []
+      [:nav.navbar.navbar-inverse.navbar-fixed-top
+       [:div.container
+        [:div.navbar-header
+         [:button.navbar-toggle
+          {:class         (when @collapsed? "collapsed")
+           :data-toggle   "collapse"
+           :aria-expanded @collapsed?
+           :aria-controls "navbar"
+           :on-click      #(swap! collapsed? not)}
+          [:span.sr-only "Toggle Navigation"]
+          [:span.icon-bar]
+          [:span.icon-bar]
+          [:span.icon-bar]]
+         [:a.navbar-brand {:href "#/"} "myapp"]]
+        [:div.navbar-collapse.collapse
+         (when @collapsed? {:class "in"})
+         [:ul.nav.navbar-nav
+          [:li {:class (when (= :home (session/get :page)) "active")}
+           [:a {:href "#/"} "Home"]]
+          [:li {:class (when (= :about (session/get :page)) "active")}
+           [:a {:href "#/about"} "About"]]]]]])))
 
 (defn about-page []
   [:div.container

--- a/src/leiningen/new/luminus/cljs/src/cljs/core.cljs
+++ b/src/leiningen/new/luminus/cljs/src/cljs/core.cljs
@@ -9,11 +9,19 @@
   (:import goog.History))
 
 (defn navbar []
-  [:div.navbar.navbar-inverse.navbar-fixed-top
+  [:nav.navbar.navbar-inverse.navbar-fixed-top
    [:div.container
     [:div.navbar-header
+     [:button.navbar-toggle.collapsed {:data-toggle   "collapse"
+                                       :data-target   "#my-navbar"
+                                       :aria-expanded "false"
+                                       :aria-controls "navbar"}
+      [:span.sr-only "Toggle Navigation"]
+      [:span.icon-bar]
+      [:span.icon-bar]
+      [:span.icon-bar]]
      [:a.navbar-brand {:href "#/"} "myapp"]]
-    [:div.navbar-collapse.collapse
+    [:div#my-navbar.navbar-collapse.collapse
      [:ul.nav.navbar-nav
       [:li {:class (when (= :home (session/get :page)) "active")}
        [:a {:href "#/"} "Home"]]

--- a/src/leiningen/new/luminus/cljs/templates/home.html
+++ b/src/leiningen/new/luminus/cljs/templates/home.html
@@ -1,6 +1,7 @@
 <html>
   <head>
       <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1"
       <title>Welcome to <<name>></title>
   </head>
   <body>
@@ -17,6 +18,10 @@
     {% style "/assets/bootstrap/css/bootstrap.min.css" %}
     {% style "/assets/bootstrap/css/bootstrap-theme.min.css" %}
     {% style "/css/screen.css" %}
+
+    {% script "/assets/jquery/jquery.min.js" %}
+    {% script "/assets/bootstrap/js/bootstrap.min.js" %}
+    {% script "/assets/bootstrap/js/collapse.js" %}
 
     <script type="text/javascript">
         var context = "{{servlet-context}}";

--- a/src/leiningen/new/luminus/cljs/templates/home.html
+++ b/src/leiningen/new/luminus/cljs/templates/home.html
@@ -1,7 +1,7 @@
 <html>
   <head>
       <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1"
+      <meta name="viewport" content="width=device-width, initial-scale=1">
       <title>Welcome to <<name>></title>
   </head>
   <body>
@@ -18,10 +18,6 @@
     {% style "/assets/bootstrap/css/bootstrap.min.css" %}
     {% style "/assets/bootstrap/css/bootstrap-theme.min.css" %}
     {% style "/css/screen.css" %}
-
-    {% script "/assets/jquery/jquery.min.js" %}
-    {% script "/assets/bootstrap/js/bootstrap.min.js" %}
-    {% script "/assets/bootstrap/js/collapse.js" %}
 
     <script type="text/javascript">
         var context = "{{servlet-context}}";


### PR DESCRIPTION
this change adds the required HTML and JS changes to make sure the
navbar works on both large and small displays, collapsing into a
dropdown menu. Taken from the bootstrap example at
http://getbootstrap.com/examples/navbar-fixed-top/