### PR TITLE
deleted settings that are equal to default

### DIFF
--- a/src/leiningen/new/cljs.clj
+++ b/src/leiningen/new/cljs.clj
@@ -43,8 +43,8 @@
 (def cljs-dev
   {:cljsbuild {:builds
                {:app
-                {:compiler {:source-map true}
-                 :source-paths ["env/dev/cljs"]}}}})
+                {:source-paths ["env/dev/cljs"]
+                 :compiler {:source-map true}}}}})
 
 (defn figwheel [{:keys [project-ns]}]
   {:http-server-root "public"

--- a/src/leiningen/new/cljs.clj
+++ b/src/leiningen/new/cljs.clj
@@ -29,9 +29,7 @@
 (def cljs-build
   {:builds {:app {:source-paths ["src-cljs"]
                   :compiler     {:output-to     "resources/public/js/app.js"
-                                 :output-dir    "resources/public/js/out"
                                  :externs       ["react/externs/react.js"]
-                                 :optimizations :none
                                  :pretty-print  true}}}})
 
 (def cljs-uberjar


### PR DESCRIPTION
Very minor change.

Some settings specified in cljs.clj are the same as the default and thus redundant. See:
https://github.com/clojure/clojurescript/wiki/Compiler-Options#output-dir
https://github.com/clojure/clojurescript/wiki/Compiler-Options#optimizations

There were also some inconsistencies about the ordering of the keys.