### PR TITLE
add missing server context

### DIFF
--- a/src/leiningen/new/luminus/cljs/src/cljs/core.cljs
+++ b/src/leiningen/new/luminus/cljs/src/cljs/core.cljs
@@ -89,7 +89,7 @@
 ;; -------------------------
 ;; Initialize app
 (defn fetch-docs! []
-  (GET "/docs" {:handler #(session/put! :docs %)}))
+  (GET (str js/context "/docs") {:handler #(session/put! :docs %)}))
 
 (defn mount-components []
   (reagent/render [#'navbar] (.getElementById js/document "navbar"))


### PR DESCRIPTION
When a luminus app is deployed using a server context path other than "/" the client cannot fetch the docs, because of a missing context fetch.