### PR TITLE
fix key for monger identifier

### DIFF
--- a/src/leiningen/new/luminus/db/src/mongodb.clj
+++ b/src/leiningen/new/luminus/db/src/mongodb.clj
@@ -13,10 +13,10 @@
   (mc/insert db "users" user))
 
 (defn update-user [id first-name last-name email]
-  (mc/update db "users" {:id id}
+  (mc/update db "users" {:_id id}
              {$set {:first_name first-name
                     :last_name last-name
                     :email email}}))
 
 (defn get-user [id]
-  (mc/find-one-as-map db "users" {:id id}))
+  (mc/find-one-as-map db "users" {:_id id}))


### PR DESCRIPTION
In [monger tutorial](http://clojuremongodb.info/articles/getting_started.html), they use `_id`. (not `id`)

I also checked [mongodb documentation](http://docs.mongodb.org/manual/reference/glossary/#term-id). they introduce `_id` as primary key. 