### PR TITLE
add webjars-locator-jboss-vfs as dependency for immutant profile

### DIFF
--- a/src/leiningen/new/immutant.clj
+++ b/src/leiningen/new/immutant.clj
@@ -8,6 +8,7 @@
          (assoc :server "immutant")
          (append-options :dependencies
                          [['org.immutant/web "2.1.1"]
+                          [org.webjars/webjars-locator-jboss-vfs "0.1.0"]
                           #_['org.immutant/web "2.1.1"
                            :exclusions ['ch.qos.logback/logback-classic]]]))]
     state))


### PR DESCRIPTION
As of now, when deploying luminus app to WildFly via immutant plugin, serving webjars assets does not work, and `webjars-locator-jboss-vfs` fixes it. See also https://github.com/webjars/webjars-locator/issues/18