### PR TITLE
Workaround for "No such var: ana/forms-seq*"

### DIFF
--- a/src/leiningen/new/cljs.clj
+++ b/src/leiningen/new/cljs.clj
@@ -24,7 +24,8 @@
   [['lein-cljsbuild "1.1.1"]])
 
 (def cljs-dev-plugins
-  [['lein-figwheel "0.5.0-3"]])
+  [['lein-figwheel "0.5.0-3"]
+   ['org.clojure/clojurescript "1.7.170"]])
 
 (def clean-targets [:target-path
                     [:cljsbuild :builds :app :compiler :output-dir]


### PR DESCRIPTION
As discussed in bhauman/lein-figwheel#286, it seems that figwheel-0.5.0
raises the error above in some circumstances. As a workaround, as
suggested in the comments, an explicit dependency to clojurescruot
1.7.170 has been added to the plugins section.