### PR TITLE
Remove extra space in gitignore

### DIFF
--- a/resources/leiningen/new/luminus/core/gitignore
+++ b/resources/leiningen/new/luminus/core/gitignore
@@ -8,6 +8,6 @@ pom.xml
 /.lein-*
 profiles.clj
 /.env
- .nrepl-port
+.nrepl-port
 /log<% for item in gitignore %>
 <<item>><% endfor %>


### PR DESCRIPTION
```
❯ lein version                                                                                                                                    ✹
Leiningen 2.6.1 on Java 1.8.0_60 Java HotSpot(TM) 64-Bit Server VM
```

Remove space in front of .nrepl-port. It doesn't work for me (MAC OSX 10.7