### PR TITLE
replacing environ/luminus-config with cprop

### DIFF
--- a/resources/leiningen/new/luminus/core/env/dev/clj/env.clj
+++ b/resources/leiningen/new/luminus/core/env/dev/clj/env.clj
@@ -1,4 +1,4 @@
-(ns <<project-ns>>.config
+(ns <<project-ns>>.env
   (:require [selmer.parser :as parser]
             [clojure.tools.logging :as log]
             [<<project-ns>>.dev-middleware :refer [wrap-dev]]))

--- a/resources/leiningen/new/luminus/core/env/dev/clj/user.clj
+++ b/resources/leiningen/new/luminus/core/env/dev/clj/user.clj
@@ -1,7 +1,7 @@
 (ns user
   (:require [<<project-ns>>.handler :refer [app init destroy]]
             [luminus.http-server :as http]
-            [config.core :refer [env]]))
+            [<<project-ns>>.config :refer [env]]))
 
 (defn start []
   (http/start {:handler app

--- a/resources/leiningen/new/luminus/core/env/dev/resources/config.edn
+++ b/resources/leiningen/new/luminus/core/env/dev/resources/config.edn
@@ -1,1 +1,3 @@
-{}
+{:dev true
+ :port 3000
+ :nrepl-port 7000} ;; when :nrepl-port is set the application starts the nREPL server on load

--- a/resources/leiningen/new/luminus/core/env/prod/clj/env.clj
+++ b/resources/leiningen/new/luminus/core/env/prod/clj/env.clj
@@ -1,4 +1,4 @@
-(ns <<project-ns>>.config
+(ns <<project-ns>>.env
   (:require [clojure.tools.logging :as log]))
 
 (def defaults

--- a/resources/leiningen/new/luminus/core/env/test/resources/config.edn
+++ b/resources/leiningen/new/luminus/core/env/test/resources/config.edn
@@ -1,3 +1,3 @@
-{:production true
+{:test true
  :port 3001
  :nrepl-port 7001} ;; when :nrepl-port is set the application starts the nREPL server on load

--- a/resources/leiningen/new/luminus/core/project.clj
+++ b/resources/leiningen/new/luminus/core/project.clj
@@ -5,7 +5,7 @@
 
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [selmer "1.0.0"]
-                 [markdown-clj "0.9.85"]
+                 [markdown-clj "0.9.86"]
                  [ring-middleware-format "0.7.0"]
                  [metosin/ring-http-response "0.6.5"]
                  [bouncer "1.0.0"]

--- a/resources/leiningen/new/luminus/core/project.clj
+++ b/resources/leiningen/new/luminus/core/project.clj
@@ -6,7 +6,6 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [selmer "1.0.0"]
                  [markdown-clj "0.9.85"]
-                 [luminus/config "0.8"]
                  [ring-middleware-format "0.7.0"]
                  [metosin/ring-http-response "0.6.5"]
                  [bouncer "1.0.0"]
@@ -22,19 +21,20 @@
                  [ring-ttl-session "0.3.0"]<% endifunequal %>
                  [ring "1.4.0" :exclusions [ring/ring-jetty-adapter]]
                  [mount "0.1.9"]
+                 [cprop "0.1.3-SNAPSHOT"]
                  [luminus-nrepl "0.1.2"]
                  <<dependencies>>]
 
   :min-lein-version "<<min-lein-version>>"
 
-  :jvm-opts ["-server"]<% if resource-paths %>
+  :jvm-opts ["-server" "-Dconf=config.edn"]<% if resource-paths %>
   :source-paths <<source-paths>>
   :resource-paths <<resource-paths>><% endif %>
 
   :main <<project-ns>>.core<% if migrations %>
   :migratus <<migrations>><% endif %>
 
-  :plugins [[lein-environ "1.0.1"]<% if plugins %>
+  :plugins [<% if plugins %>
             <<plugins>><% endif %>]<% if cucumber-feature-paths %>
   :cucumber-feature-paths <<cucumber-feature-paths>><% endif %><% if sassc-config-params %>
   <<sassc-config-params>>
@@ -47,7 +47,7 @@
   <<cljs-build>><% endif %>
   :profiles
   {:uberjar {:omit-source true
-             :env {:production true}<% if cljs-uberjar %>
+             <% if cljs-uberjar %>
              <<cljs-uberjar>><% endif %>
              :aot :all
              :uberjar-name "<<name>>.jar"
@@ -68,13 +68,7 @@
                   :resource-paths ["env/dev/resources"]
                   :repl-options {:init-ns user}
                   :injections [(require 'pjstadig.humane-test-output)
-                               (pjstadig.humane-test-output/activate!)]
-                  ;;when :nrepl-port is set the application starts the nREPL server on load
-                  :env {:dev        true
-                        :port       3000
-                        :nrepl-port 7000}}
-   :project/test {:env {:test       true
-                        :port       3001
-                        :nrepl-port 7001}}
+                               (pjstadig.humane-test-output/activate!)]}
+   :project/test {:resource-paths ["env/dev/resources" "env/test/resources"]}
    :profiles/dev {}
    :profiles/test {}})

--- a/resources/leiningen/new/luminus/core/project.clj
+++ b/resources/leiningen/new/luminus/core/project.clj
@@ -21,7 +21,7 @@
                  [ring-ttl-session "0.3.0"]<% endifunequal %>
                  [ring "1.4.0" :exclusions [ring/ring-jetty-adapter]]
                  [mount "0.1.9"]
-                 [cprop "0.1.3-SNAPSHOT"]
+                 [cprop "0.1.4"]
                  [luminus-nrepl "0.1.2"]
                  <<dependencies>>]
 

--- a/resources/leiningen/new/luminus/core/src/config.clj
+++ b/resources/leiningen/new/luminus/core/src/config.clj
@@ -1,0 +1,5 @@
+(ns <<project-ns>>.config
+  (:require [cprop.core :refer [load-config]]
+            [mount.core :refer [defstate]]))
+
+(defstate env :start (load-config))

--- a/resources/leiningen/new/luminus/core/src/core.clj
+++ b/resources/leiningen/new/luminus/core/src/core.clj
@@ -3,7 +3,8 @@
             [luminus.repl-server :as repl]
             [luminus.http-server :as http]<% if relational-db %>
             [<<project-ns>>.db.migrations :as migrations]<% endif %>
-            [config.core :refer [env]])
+            [<<project-ns>>.config :refer [env]]
+            [mount.core :as mount])
   (:gen-class))
 
 (defn parse-port [port]
@@ -26,6 +27,7 @@
 (defn start-app
   "e.g. lein run 3000"
   [[port]]
+  (mount/start)
   (let [port (http-port port)]
     (.addShutdownHook (Runtime/getRuntime) (Thread. stop-app))
     (when-let [repl-port (env :nrepl-port)]

--- a/resources/leiningen/new/luminus/core/src/handler.clj
+++ b/resources/leiningen/new/luminus/core/src/handler.clj
@@ -6,8 +6,8 @@
             [<<project-ns>>.middleware :as middleware]
             [clojure.tools.logging :as log]
             [compojure.route :as route]
-            [config.core :refer [env]]
-            [<<project-ns>>.config :refer [defaults]]
+            [<<project-ns>>.config :refer [env]]
+            [<<project-ns>>.env :refer [defaults]]
             [mount.core :as mount]
             [luminus.logger :as logger]))
 

--- a/resources/leiningen/new/luminus/core/src/middleware.clj
+++ b/resources/leiningen/new/luminus/core/src/middleware.clj
@@ -1,7 +1,7 @@
 (ns <<project-ns>>.middleware
   (:require [<<project-ns>>.layout :refer [*app-context* error-page]]
             [clojure.tools.logging :as log]
-            [config.core :refer [env]]<% ifequal server "immutant" %>
+            [<<project-ns>>.config :refer [env]]<% ifequal server "immutant" %>
             [ring.middleware.flash :refer [wrap-flash]]
             [immutant.web.middleware :refer [wrap-session]]<% else %>
             [ring-ttl-session.core :refer [ttl-memory-store]]<% endifequal %>
@@ -10,7 +10,7 @@
             [ring.middleware.anti-forgery :refer [wrap-anti-forgery]]
             [ring.middleware.format :refer [wrap-restful-format]]<% if auth-middleware-required %>
             <<auth-middleware-required>><% endif %>
-            [<<project-ns>>.config :refer [defaults]])
+            [<<project-ns>>.env :refer [defaults]])
   (:import [javax.servlet ServletContext]))
 
 (defn wrap-context [handler]

--- a/resources/leiningen/new/luminus/db/src/migrations.clj
+++ b/resources/leiningen/new/luminus/db/src/migrations.clj
@@ -1,7 +1,7 @@
 (ns <<project-ns>>.db.migrations
   (:require
     [migratus.core :as migratus]
-    [config.core :refer [env]]
+    [<<project-ns>>.config :refer [env]]
     [to-jdbc-uri.core :refer [to-jdbc-uri]]))
 
 (defn parse-ids [args]

--- a/resources/leiningen/new/luminus/db/src/mongodb.clj
+++ b/resources/leiningen/new/luminus/db/src/mongodb.clj
@@ -2,7 +2,7 @@
     (:require [monger.core :as mg]
               [monger.collection :as mc]
               [monger.operators :refer :all]
-              [config.core :refer [env]]))
+              [<<project-ns>>.config :refer [env]]))
 
 
 (defonce db (atom nil))

--- a/resources/leiningen/new/luminus/db/src/sql.db.clj
+++ b/resources/leiningen/new/luminus/db/src/sql.db.clj
@@ -2,12 +2,12 @@
   (:require
     [conman.core :as conman]
     [mount.core :refer [defstate]]
-    [config.core :refer [env]])<% endif %><% ifequal db-type "postgres" %>
+    [<<project-ns>>.config :refer [env]])<% endif %><% ifequal db-type "postgres" %>
   (:require
     [cheshire.core :refer [generate-string parse-string]]
     [clojure.java.jdbc :as jdbc]
     [conman.core :as conman]
-    [config.core :refer [env]]
+    [<<project-ns>>.config :refer [env]]
     [mount.core :refer [defstate]])
   (:import org.postgresql.util.PGobject
            org.postgresql.jdbc4.Jdbc4Array
@@ -21,7 +21,7 @@
   (:require
     [clojure.java.jdbc :as jdbc]
     [conman.core :as conman]
-    [config.core :refer [env]]
+    [<<project-ns>>.config :refer [env]]
     [mount.core :refer [defstate]])
   (:import [java.sql
             BatchUpdateException

--- a/resources/leiningen/new/luminus/db/test/db/core.clj
+++ b/resources/leiningen/new/luminus/db/test/db/core.clj
@@ -3,7 +3,7 @@
             [<<project-ns>>.db.migrations :as migrations]
             [clojure.test :refer :all]
             [clojure.java.jdbc :as jdbc]
-            [config.core :refer [env]]
+            [<<project-ns>>.config :refer [env]]
             [mount.core :as mount]))
 
 (use-fixtures

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -31,14 +31,18 @@
    ["Procfile" "core/Procfile"]
    ["README.md" "core/README.md"]
    ["env/prod/resources/config.edn" "core/env/prod/resources/config.edn"]
+   ["env/dev/resources/config.edn" "core/env/dev/resources/config.edn"]
+   ["env/test/resources/config.edn" "core/env/test/resources/config.edn"]
 
    ;; config namespaces
-   ["env/dev/clj/{{sanitized}}/config.clj" "core/env/dev/clj/config.clj"]
+   ["env/dev/clj/{{sanitized}}/env.clj" "core/env/dev/clj/env.clj"]
    ["env/dev/clj/{{sanitized}}/dev_middleware.clj" "core/env/dev/clj/dev_middleware.clj"]
-   ["env/prod/clj/{{sanitized}}/config.clj" "core/env/prod/clj/config.clj"]
+   ["env/prod/clj/{{sanitized}}/env.clj" "core/env/prod/clj/env.clj"]
+
    ;; core namespaces
    ["env/dev/clj/user.clj" "core/env/dev/clj/user.clj"]
    ["src/clj/{{sanitized}}/core.clj" "core/src/core.clj"]
+   ["src/clj/{{sanitized}}/config.clj" "core/src/config.clj"]
    ["src/clj/{{sanitized}}/handler.clj" "core/src/handler.clj"]
    ["src/clj/{{sanitized}}/routes/home.clj" "core/src/home.clj"]
    ["src/clj/{{sanitized}}/layout.clj" "core/src/layout.clj"]


### PR DESCRIPTION
replacing `lein-environ` / `luminus-config` with [cprop](https://github.com/tolitius/cprop)

* config comes from `env/dev|test|prod/resources/config.edn`
* new `<<project-ns>>.config` namespace that has a config state
* `(mount/start)` need to be called on `start-app` to start this config state