### PR TITLE
Update +auth (Buddy) URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ However, if you would like to attach further functionality to your template you 
 
 ### misc
 
-* `+auth` adds [Buddy](https://funcool.github.io/buddy/latest/) dependency and authentication middleware
+* `+auth` adds [Buddy](https://github.com/funcool/buddy) dependency and authentication middleware
 * `+cljs` adds [ClojureScript][cljs] support to the project along with an example
 * `+cucumber` adds support for browser based UI testing with [Cucumber][cucumber] and [clj-webdriver][clj-webdriver]
 * `+swagger` adds support for [Swagger-UI](https://github.com/swagger-api/swagger-ui) using the [compojure-api](https://github.com/metosin/compojure-api) library


### PR DESCRIPTION
Buddy's documentation URL has been split into pieces when Buddy was made into modules. This updates the link to point to the root repository, which links to the new submodules in it's README.md which is displayed at the new URL.