### PR TITLE
Profile-dependent target path to avoid cross-profile contamination

### DIFF
--- a/resources/leiningen/new/luminus/core/project.clj
+++ b/resources/leiningen/new/luminus/core/project.clj
@@ -47,6 +47,7 @@
   :clean-targets ^{:protect false} <<clean-targets>><% endif %><% if cljs-build %>
   :cljsbuild
   <<cljs-build>><% endif %>
+  :target-path "target/%s/"
   :profiles
   {:uberjar {:omit-source true
              <% if cljs-uberjar %>


### PR DESCRIPTION
`:target-path` for generated project was not set, so the default `target/` was used, which lead to contamination (e.g. after `lein uberjar`, `lein run` used config class compiled from `env/prod/project-name/...`, not `env/dev/project-name/...`).

It this PR `:target-path` is set to include current profiles, as [recommended](https://github.com/technomancy/leiningen/blob/master/sample.project.clj) by leiningen.