### PR TITLE
Specify required lein version in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}
+  :min-lein-version "2.5.3"
   :eval-in-leiningen true
   :dependencies [[leinjacker "0.4.2"]
                  [selmer "1.0.3"]])


### PR DESCRIPTION
This way the user at least gets a warning when their lein is behind.