### PR TITLE
fix hikari-cp issue: `:driver-class-name` needed if `:jdbc-url` used

### DIFF
--- a/resources/leiningen/new/luminus/db/src/sql.db.clj
+++ b/resources/leiningen/new/luminus/db/src/sql.db.clj
@@ -49,6 +49,7 @@
                     :min-idle   1
                     :max-idle   4
                     :max-active 32
+                    :driver-class-name "org.postgresql.Driver"
                     :jdbc-url   (env :database-url)})
           :stop (conman/disconnect! *db*))
 <% endifequal %><% ifequal db-type "mysql" %>


### PR DESCRIPTION
mysql probably have the same issue but i dont use it:/. I checked hikari-cp code and schema used for validate options need this parametr if `:jdbc-url` present

PS. Sorry for my english:/. I hope you can understand me.