### PR TITLE
add more detail on connecting template app to databases

### DIFF
--- a/resources/leiningen/new/luminus/db/docs/db_instructions.md
+++ b/resources/leiningen/new/luminus/db/docs/db_instructions.md
@@ -7,7 +7,7 @@ If you haven't already, then please follow the steps below to configure your dat
 * Create the database for your application.
 * Update the connection URL in the `profiles.clj` file with your database name and login.
 * Run `lein run migrate` in the root of the project to create the tables.
-* Let `mount` know to start the database connection by `require`-ing your-app.db.core in some other namespace.
+* Let `mount` know to start the database connection by `require`-ing <<project-ns>>.db.core in some other namespace.
 * Restart the application.
 
 </div>

--- a/resources/leiningen/new/luminus/db/docs/db_instructions.md
+++ b/resources/leiningen/new/luminus/db/docs/db_instructions.md
@@ -7,6 +7,7 @@ If you haven't already, then please follow the steps below to configure your dat
 * Create the database for your application.
 * Update the connection URL in the `profiles.clj` file with your database name and login.
 * Run `lein run migrate` in the root of the project to create the tables.
+* Let `mount` know to start the database connection by `require`-ing your-app.db.core in some other namespace.
 * Restart the application.
 
 </div>

--- a/resources/leiningen/new/luminus/db/docs/h2_instructions.md
+++ b/resources/leiningen/new/luminus/db/docs/h2_instructions.md
@@ -5,7 +5,7 @@
 If you haven't already, then please follow the steps below to configure your database connection and run the necessary migrations.
 
 * Run `lein run migrate` in the root of the project to create the tables.
-* Let `mount` know to start the database connection by `require`-ing your-app.db.core in some other namespace.
+* Let `mount` know to start the database connection by `require`-ing <<project-ns>>.db.core in some other namespace.
 * Restart the application.
 
 </div>

--- a/resources/leiningen/new/luminus/db/docs/h2_instructions.md
+++ b/resources/leiningen/new/luminus/db/docs/h2_instructions.md
@@ -5,6 +5,7 @@
 If you haven't already, then please follow the steps below to configure your database connection and run the necessary migrations.
 
 * Run `lein run migrate` in the root of the project to create the tables.
+* Let `mount` know to start the database connection by `require`-ing your-app.db.core in some other namespace.
 * Restart the application.
 
 </div>

--- a/resources/leiningen/new/luminus/db/docs/mongo_instructions.md
+++ b/resources/leiningen/new/luminus/db/docs/mongo_instructions.md
@@ -6,6 +6,7 @@ If you haven't already, then please follow the steps below to configure your Mon
 
 * Ensure that MongoDB is up and running.
 * Set the connection parameters in the `profiles.clj` file.
+* Let `mount` know to start the database connection by `require`-ing your-app.db.core in some other namespace.
 * Restart the application.
 
 </div>

--- a/resources/leiningen/new/luminus/db/docs/mongo_instructions.md
+++ b/resources/leiningen/new/luminus/db/docs/mongo_instructions.md
@@ -6,7 +6,7 @@ If you haven't already, then please follow the steps below to configure your Mon
 
 * Ensure that MongoDB is up and running.
 * Set the connection parameters in the `profiles.clj` file.
-* Let `mount` know to start the database connection by `require`-ing your-app.db.core in some other namespace.
+* Let `mount` know to start the database connection by `require`-ing <<project-ns>>.core in some other namespace.
 * Restart the application.
 
 </div>


### PR DESCRIPTION
Adds a bullet point to the default instructions that appear on template versions with database integration, informing users that they need to require the db.core namespace in order to get mount to automatically connect to the database.