### PR TITLE
:dependencies instead of :dev-plugins to bundle cider-nrepl in jar or war

### DIFF
--- a/src/leiningen/new/cider.clj
+++ b/src/leiningen/new/cider.clj
@@ -6,5 +6,5 @@
     [assets
      (-> options
          (assoc :cider true)
-         (append-options :dev-plugins [['cider/cider-nrepl "0.14.0-SNAPSHOT"]]))]
+         (append-options :dependencies [['cider/cider-nrepl "0.14.0-SNAPSHOT"]]))]
     state))


### PR DESCRIPTION
cider-nrepl should be in :dependecies instead of :dev-plugins as it's required in core.clj.