### PR TITLE
add the content-type to the /docs route

### DIFF
--- a/resources/leiningen/new/luminus/core/src/home.clj
+++ b/resources/leiningen/new/luminus/core/src/home.clj
@@ -9,7 +9,8 @@
 
 (defroutes home-routes
   (GET "/" [] (home-page))
-  (GET "/docs" [] (response/ok (-> "docs/docs.md" io/resource slurp))))
+  (GET "/docs" [] (-> (response/ok (-> "docs/docs.md" io/resource slurp))
+                      (response/header "Content-Type" "text/plain; charset=utf-8"))))
 <% else %>
 (defn home-page []
   (layout/render


### PR DESCRIPTION
There was some encoding problem with non-ASCII char because the markdown file
was read as octet-stream.

Should I do the same thing for `else` branch? There is
```clojure
  (layout/render
    "home.html" {:docs (-> "docs/docs.md" io/resource slurp)})
```
I didn't test the encoding problem for this part.

Cheers