### PR TITLE
Auth-jwe dependency update

### DIFF
--- a/resources/leiningen/new/luminus/core/src/middleware.clj
+++ b/resources/leiningen/new/luminus/core/src/middleware.clj
@@ -10,7 +10,8 @@
             [immutant.web.middleware :refer [wrap-session]]<% else %>
             [ring-ttl-session.core :refer [ttl-memory-store]]<% endif %>
             [ring.middleware.defaults :refer [site-defaults wrap-defaults]]<% if auth-middleware-required %>
-            <<auth-middleware-required>><% endif %>)<% if not service %>
+            <<auth-middleware-required>><% if auth-jwe %>
+            <<auth-jwe>><% endif %><% endif %>)<% if not service %>
   (:import [javax.servlet ServletContext])<% endif %>)
 <% if not service %>
 (defn wrap-context [handler]
@@ -64,26 +65,14 @@
   {:status 403
    :headers {}
    :body (str "Access to " (:uri request) " is not authorized")})
-<% endif %><% if not service %>
+<% endif %>
 (defn wrap-restricted [handler]
   (restrict handler {:handler authenticated?
-                     :on-error on-error}))
+                     :on-error on-error}))<% if auth-jwe %>
 
-(defn wrap-identity [handler]
-  (fn [request]
-    (binding [*identity* (get-in request [:session :identity])]
-      (handler request))))
-
-(defn wrap-auth [handler]
-  (let [backend (session-backend)]
-    (-> handler
-        wrap-identity
-        (wrap-authentication backend)
-        (wrap-authorization backend))))
-<% else %>
 (def secret (random-bytes 32))
 
-(def auth-backend (jwe-backend {:secret secret
+(def token-backend (jwe-backend {:secret secret
                                 :options {:alg :a256kw
                                           :enc :a128gcm}}))
 
@@ -91,13 +80,19 @@
   (let [claims {:user (keyword username)
                 :exp (plus (now) (minutes 60))}]
     (encrypt claims secret {:alg :a256kw :enc :a128gcm})))
-
+<% else %>
+(defn wrap-identity [handler]
+  (fn [request]
+    (binding [*identity* (get-in request [:session :identity])]
+      (handler request))))
+<% endif %>
 (defn wrap-auth [handler]
-  (let [backend auth-backend]
-    (-> handler
+  (let [backend <% if auth-jwe %>token-backend<% else %>(session-backend)<% endif %>]
+    (-> handler<% if not auth-jwe %>
+        wrap-identity<% endif %>
         (wrap-authentication backend)
         (wrap-authorization backend))))
-<% endif %><% endif %>
+<% endif %>
 (defn wrap-base [handler]
   (-> ((:middleware defaults) handler)<% if auth-middleware-required %>
       wrap-auth<% endif %><% if not service %>

--- a/src/leiningen/new/auth.clj
+++ b/src/leiningen/new/auth.clj
@@ -5,13 +5,8 @@
   (if (some #{"+auth"} (:features options))
     [assets
      (-> options
-         (assoc :auth true)
-         (append-options :dependencies [['buddy "1.0.0"]])
-         (append-formatted :auth-middleware-required
-                           [['buddy.auth.middleware :refer ['wrap-authentication 'wrap-authorization]]
-                            ['buddy.auth.backends.session :refer ['session-backend]]
-                            ['buddy.auth.accessrules :refer ['restrict]]
-                            ['buddy.auth :refer ['authenticated?]]
+         (append-formatted :auth-session
+                           [['buddy.auth.backends.session :refer ['session-backend]]
                             [(symbol (str (:project-ns options) ".layout")) :refer ['*identity*]]]
                            plugin-indent))]
     state))

--- a/src/leiningen/new/auth_base.clj
+++ b/src/leiningen/new/auth_base.clj
@@ -1,0 +1,15 @@
+(ns leiningen.new.auth-base
+  (:require [leiningen.new.common :refer :all]))
+
+(defn auth-base-features [[assets options :as state]]
+  (if (some #{"+auth-base"} (:features options))
+    [assets
+     (-> options
+         (assoc :auth true)
+         (append-options :dependencies [['buddy "1.0.0"]])
+         (append-formatted :auth-middleware-required
+                           [['buddy.auth.middleware :refer ['wrap-authentication 'wrap-authorization]]
+                            ['buddy.auth.accessrules :refer ['restrict]]
+                            ['buddy.auth :refer ['authenticated?]]]
+                           plugin-indent))]
+    state))

--- a/src/leiningen/new/auth_jwe.clj
+++ b/src/leiningen/new/auth_jwe.clj
@@ -5,15 +5,11 @@
   (if (some #{"+auth-jwe"} (:features options))
     [assets
      (-> options
-         (assoc :auth true)
-         (append-options :dependencies [['buddy "1.0.0"] ['clj-time "0.8.0"]])
+         (append-options :dependencies [['clj-time "0.8.0"]])
          (append-formatted :auth-middleware-required
-                           [['buddy.auth.middleware :refer ['wrap-authentication 'wrap-authorization]]
-                            ['buddy.auth.backends.token :refer ['jwe-backend]]
+                            [['buddy.auth.backends.token :refer ['jwe-backend]]
                             ['buddy.sign.jwt :refer ['encrypt]]
                             ['buddy.core.nonce :refer ['random-bytes]]  
-                            ['buddy.auth.accessrules :refer ['restrict]]
-                            ['buddy.auth :refer ['authenticated? 'throw-unauthorized]]
                             ['clj-time.core :refer ['plus 'now 'minutes]]]
                            plugin-indent))]
     state))

--- a/src/leiningen/new/auth_jwe.clj
+++ b/src/leiningen/new/auth_jwe.clj
@@ -6,7 +6,7 @@
     [assets
      (-> options
          (append-options :dependencies [['clj-time "0.8.0"]])
-         (append-formatted :auth-middleware-required
+         (append-formatted :auth-jwe
                             [['buddy.auth.backends.token :refer ['jwe-backend]]
                             ['buddy.sign.jwt :refer ['encrypt]]
                             ['buddy.core.nonce :refer ['random-bytes]]  

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -7,6 +7,7 @@
             [leiningen.core.main :as main]
             [leiningen.new.common :refer :all]
             [leiningen.new.auth :refer [auth-features]]
+            [leiningen.new.auth-base :refer [auth-base-features]]
             [leiningen.new.auth-jwe :refer [auth-jwe-features]]
             [leiningen.new.cider :refer [cider-features]]
             [leiningen.new.db :refer [db-features]]
@@ -107,6 +108,7 @@
   (let [[assets options]
         (-> [core-assets options]
             service-features
+            auth-base-features
             auth-features
             auth-jwe-features
             cider-features
@@ -150,7 +152,8 @@
 
 (defn set-dependent-features [options]
   (-> options
-      (set-feature-dependency "+auth-jwe" #{"+auth"})
+      (set-feature-dependency "+auth" #{"+auth-base"})
+      (set-feature-dependency "+auth-jwe" #{"+auth-base"})
       (set-feature-dependency "+re-frame" #{"+cljs"})))
 
 (defn parse-version [v]

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -150,7 +150,7 @@
 
 (defn set-dependent-features [options]
   (-> options
-      (set-feature-dependency "+auth-jwe" #{"+service"})
+      (set-feature-dependency "+auth-jwe" #{"+auth"})
       (set-feature-dependency "+re-frame" #{"+cljs"})))
 
 (defn parse-version [v]


### PR DESCRIPTION
So I switched out `service` for `auth` as a dependency and updated the logic of middleware. I am not sure how to extract `['buddy.auth.backends.session :refer ['session-backend]]` with this dep setup. Any thoughts? Happy to update/tweak this as necessary...