### PR TITLE
Fixed outdated clj-time version

### DIFF
--- a/src/leiningen/new/auth_jwe.clj
+++ b/src/leiningen/new/auth_jwe.clj
@@ -5,7 +5,7 @@
   (if (some #{"+auth-jwe"} (:features options))
     [assets
      (-> options
-         (append-options :dependencies [['clj-time "0.8.0"]])
+         (append-options :dependencies [['clj-time "0.12.0"]])
          (append-formatted :auth-jwe
                             [['buddy.auth.backends.token :refer ['jwe-backend]]
                             ['buddy.sign.jwt :refer ['encrypt]]


### PR DESCRIPTION
The clj-time version is incorrect in `auth-jwe` and causes swagger to break. My apologies for the incorrect versioning on the original pull...