### PR TITLE
suppress org.apache.http verbosity

### DIFF
--- a/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
@@ -24,6 +24,10 @@
             <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
         </encoder>
     </appender>
+    <logger name="org.apache.http" level="warn">
+        <AppenderRef ref="STDOUT"/>
+        <AppenderRef ref="FILE"/>
+    </logger>
     <logger name="org.xnio.nio" level="warn">
         <AppenderRef ref="STDOUT"/>
         <AppenderRef ref="FILE"/>

--- a/resources/leiningen/new/luminus/core/env/prod/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/prod/resources/logback.xml
@@ -16,6 +16,9 @@
             <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
         </encoder>
     </appender>
+    <logger name="org.apache.http" level="warn">
+        <AppenderRef ref="FILE"/>
+    </logger>
     <logger name="org.xnio.nio" level="warn">
         <AppenderRef ref="FILE"/>
     </logger><% if relational-db %>


### PR DESCRIPTION
org.apache.http logs extremely aggressively at DEBUG. Suppress by default.