### PR TITLE
Bumped cider version

### DIFF
--- a/src/leiningen/new/cider.clj
+++ b/src/leiningen/new/cider.clj
@@ -6,5 +6,5 @@
     [assets
      (-> options
          (assoc :cider true)
-         (append-options :dependencies [['cider/cider-nrepl "0.14.0-SNAPSHOT"]]))]
+         (append-options :dependencies [['cider/cider-nrepl "0.15.0-SNAPSHOT"]]))]
     state))


### PR DESCRIPTION
The latest version of cider is now using `0.15.0-SNAPSHOT`