### PR TITLE
problem with dependency conflict between +auth, +auth-jwe and +selenium

### DIFF
--- a/src/leiningen/new/cucumber.clj
+++ b/src/leiningen/new/cucumber.clj
@@ -14,9 +14,10 @@
          (append-options :dev-dependencies [['org.clojure/core.cache "0.6.3"]
                                             ['org.apache.httpcomponents/httpcore "4.4"]
                                             ['clj-webdriver/clj-webdriver "0.7.2"]
-                                            (if (some #{"+auth"} (:features options))
+                                            (if (some #{"+auth" "+auth-jwe"} (:features options))
                                               ['org.seleniumhq.selenium/selenium-server "2.48.2"
-                                               :exclusions ['org.bouncycastle/bcprov-jdk15on]]
+                                               :exclusions ['org.bouncycastle/bcprov-jdk15on
+                                                            'org.bouncycastle/bcpkix-jdk15on]]
                                               ['org.seleniumhq.selenium/selenium-server "2.48.2"])])
          (assoc :cucumber-feature-paths (pprint-code ["test/clj/features"])))]
     state))


### PR DESCRIPTION
it's related to #197

when I generated project with 
```
$ lein new luminus spike +postgres +auth-jwe +re-frame +cucumber +sassc +kibit
```

and runned project, I got:
```
Caused by: java.lang.ClassNotFoundException: org.bouncycastle.jcajce.JcaJceHelper
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
```

I fixed it by adding exclusions like was defined in #197, but this was not enough

so I added additional exclusion.

```
Caused by: java.lang.ClassNotFoundException: org.bouncycastle.crypto.digests.Blake2bDigest
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at clojure.lang.DynamicClassLoader.findClass(DynamicClassLoader.java:69)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at clojure.lang.DynamicClassLoader.loadClass(DynamicClassLoader.java:77)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
```

Summary: The problem consist of two issues:

- missing exclusion of: `org.bouncycastle/bcpkix-jdk15on`
- missing check for `auth-jwe`