### PR TITLE
Skip aot on :main in project.clj.

### DIFF
--- a/resources/leiningen/new/luminus/core/project.clj
+++ b/resources/leiningen/new/luminus/core/project.clj
@@ -12,7 +12,7 @@
   :test-paths ["test/clj"]
   :resource-paths <<resource-paths>><% endif %>
   :target-path "target/%s/"
-  :main <<project-ns>>.core<% if migrations %>
+  :main ^:skip-aot <<project-ns>>.core<% if migrations %>
   :migratus <<migrations>><% endif %>
 
   :plugins [[lein-cprop "1.0.1"]<% if plugins %>


### PR DESCRIPTION
Otherwise there will be unnecessary AOT, which can lead to confusing behavior.