### PR TITLE
Update Muuntaja to 0.2.1

### DIFF
--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -97,7 +97,7 @@
   [['org.clojure/clojure "1.8.0"]
    ['selmer "1.10.7"]
    ['markdown-clj "0.9.98"]
-   ['metosin/muuntaja "0.2.0"]
+   ['metosin/muuntaja "0.2.1"]
    ['metosin/ring-http-response "0.8.2"]
    ['funcool/struct "1.0.0"]
    ['org.webjars/bootstrap "4.0.0-alpha.5"]


### PR DESCRIPTION
* fixes https://github.com/metosin/muuntaja/issues/39 (msgpack dependency spill)