### PR TITLE
Remove time dependency from auth-jwe

### DIFF
--- a/src/leiningen/new/auth_jwe.clj
+++ b/src/leiningen/new/auth_jwe.clj
@@ -5,7 +5,6 @@
   (if (some #{"+auth-jwe"} (:features options))
     [assets
      (-> options
-         (append-options :dependencies [['clj-time "0.12.0"]])
          (append-formatted :auth-jwe
                             [['buddy.auth.backends.token :refer ['jwe-backend]]
                             ['buddy.sign.jwt :refer ['encrypt]]


### PR DESCRIPTION
First of all, thanks for this project, you are doing a great work.

Since clj-time was added to the core dependencies, this is not needed anymore. When generating with +auth-jwe option, it was added to dependencies twice and with different version.