### PR TITLE
Added :oauth key to options

### DIFF
--- a/src/leiningen/new/oauth.clj
+++ b/src/leiningen/new/oauth.clj
@@ -14,5 +14,6 @@
                 (indent require-indent
                         [[(symbol (str (:project-ns options) ".routes.oauth")) :refer ['oauth-routes]]])
                 :oauth-routes
-                (indent dev-indent ["#'oauth-routes"])))]
+                (indent dev-indent ["#'oauth-routes"])
+                :oauth true))]
     state))


### PR DESCRIPTION
The oauth environment variables were not being generated in env/dev/resources/config.edn and env/prod/resources/config.edn. Added a key to options that will trigger the generation.