### PR TITLE
Adds support for a luminus project built with boot, rather than lein

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ However, if you would like to attach further functionality to your template you 
 
 ### misc
 
+* `+boot` causes the project to run with [Boot](https://github.com/boot-clj/boot) instead of [Leiningen](https://github.com/technomancy/leiningen/)
 * `+auth` adds [Buddy](https://github.com/funcool/buddy) dependency and authentication middleware
 * `+auth-jwe` adds [Buddy](https://github.com/funcool/buddy) dependency with the [JWE](https://jwcrypto.readthedocs.io/en/stable/jwe.html) backend
 * `+oauth` adds [OAuth](https://github.com/mattrepl/clj-oauth) dependency
@@ -67,6 +68,10 @@ To build as a executable [Java ARchive (JAR)][jar] standalone, run the following
 
 ```bash
 lein uberjar
+```
+Or if using the +boot profile:
+```bash
+boot uberjar
 ```
 
 To run the resulting standalone executable `.jar` file, do as you would with any other:

--- a/resources/leiningen/new/luminus/cljs/templates/home.html
+++ b/resources/leiningen/new/luminus/cljs/templates/home.html
@@ -12,8 +12,9 @@
         <div class="card-deck">
           <div class="card-block">
             <h4>Welcome to <<name>></h4>
-            <p>If you're seeing this message, that means you haven't yet compiled your ClojureScript!</p>
-            <p>Please run <code>lein figwheel</code> to start the ClojureScript compiler and reload the page.</p>
+            <p>If you're seeing this message, that means you haven't yet compiled your ClojureScript!</p><% if not boot %>
+            <p>Please run <code>lein figwheel</code> to start the ClojureScript compiler and reload the page.</p><% else %>
+            <p>Please close this process and start the server with <code>boot figwheel</code> to enable the ClojureScript compiler.<% endif %>
             <h4>For better ClojureScript development experience in Chrome follow these steps:</h4>
             <ul>
               <li>Open DevTools

--- a/resources/leiningen/new/luminus/core/README.md
+++ b/resources/leiningen/new/luminus/core/README.md
@@ -13,8 +13,11 @@ You will need [Leiningen][1] 2.0 or above installed.
 ## Running
 
 To start a web server for the application, run:
-
-    lein run
+<% if not boot %>
+    lein run 
+<% else %>
+    boot run
+<% endif %>
 
 ## License
 

--- a/resources/leiningen/new/luminus/core/README.md.in
+++ b/resources/leiningen/new/luminus/core/README.md.in
@@ -13,9 +13,11 @@ You will need [Leiningen][1] 2.0 or above installed.
 ## Running
 
 To start a web server for the application, run:
-
-    lein run
-
+<% if not boot %>
+    lein run 
+<% else %>
+    boot run
+<% endif %>
 ## License
 
 Copyright © <<year>> FIXME

--- a/resources/leiningen/new/luminus/core/build.boot
+++ b/resources/leiningen/new/luminus/core/build.boot
@@ -1,0 +1,115 @@
+(set-env!
+ :dependencies '[<<dependencies>>]<% if resource-paths %>
+ :source-paths <<source-paths>>
+ :resource-paths <<resource-paths>><% endif %>)
+<% if cljs %>
+(require '[adzerk.boot-cljs :refer [cljs]]
+         '[adzerk.boot-cljs-repl :refer [cljs-repl]])
+<% endif %><% if sassc-config-params %>
+(require '[deraen.boot-sass :refer [sass]])
+<% endif %>
+(deftask dev
+  "Enables configuration for a development setup."
+  []
+  (set-env!
+   :source-paths #(conj % "env/dev/clj"<% if cljs %> <<dev-cljs.source-paths>><% endif %>)
+   :resource-paths #(conj % "env/dev/resources")
+   :dependencies #(concat % '[[prone "1.1.4"]
+                              [ring/ring-mock "0.3.0"]
+                              [ring/ring-devel "1.6.1"]<% if war %>
+                              <<dev-http-server-dependencies>><% endif %>
+                              [pjstadig/humane-test-output "0.8.2"]<% if dev-dependencies %>
+                              <<dev-dependencies>><% endif %>]))
+  (task-options! repl {:init-ns 'user})
+  (require 'pjstadig.humane-test-output)
+  (let [pja (resolve 'pjstadig.humane-test-output/activate!)]
+    (pja))
+  identity)
+
+(deftask testing
+  "Enables configuration for testing."
+  []
+  (dev)
+  (set-env! :resource-paths #(conj % "env/test/resources"))<% if cljs %>
+  (merge-env! :source-paths <<dev-cljs.test.source-paths>>)<% endif %>
+  identity)
+
+(deftask prod
+  "Enables configuration for production building."
+  []
+  (merge-env! :source-paths #{"env/prod/clj"<% if cljs %> "env/prod/cljs"<% endif %>}
+              :resource-paths #{"env/prod/resources"})
+  identity)
+
+(deftask start-server
+  "Runs the project without building class files.
+
+  This does not pause execution. Combine with a wait task or use the \"run\"
+  task."
+  []
+  (require '<<project-ns>>.core)
+  (let [m (resolve '<<project-ns>>.core/-main)]
+    (with-pass-thru _
+      (m))))
+
+(deftask run
+  "Starts the server and causes it to wait."
+  []
+  (comp
+   (start-server)
+   (wait)))
+<% if cljs %>
+(require '[clojure.java.io :as io])
+(require '[crisptrutski.boot-cljs-test :refer [test-cljs]])
+(deftask figwheel
+  "Runs figwheel and enables reloading."
+  []
+  (dev)
+  (require '[powerlaces.boot-figreload :refer [reload]])
+  (let [reload (resolve 'powerlaces.boot-figreload/reload)]
+    (comp
+     (reload {:client-opts {:debug true}})
+     (cljs-repl)
+     (cljs)
+     (start-server)
+     (wait))))
+
+(deftask run-cljs-tests
+  "Runs the doo tests for ClojureScript."
+  []
+  (comp
+   (testing)
+   (test-cljs :cljs-opts <<dev-cljs.test.compiler>>)))
+<% endif %>
+(deftask uberjar
+  "Builds an uberjar of this project that can be run with java -jar"
+  []
+  (comp
+   (prod)
+   (aot :namespace #{'<<project-ns>>.core})<% if cljs %>
+   (cljs :optimizations :advanced)<% endif %>
+   (uber)
+   (jar :file "<<name>>.jar" :main '<<project-ns>>.core)
+   (sift :include #{#"<<name>>.jar"})
+   (target)))
+<% if war %>
+(require '[boot.immutant :refer [gird]])
+(deftask uberwar
+  "Creates a war file ready to deploy to wildfly."
+  []
+  (comp
+   (uber :as-jars true)
+   (aot :all true)
+   (gird :init-fn '<<project-ns>>.handler/init)
+   (war)
+   (target)))
+
+(deftask dev-war
+  "Creates a war file for development and testing."
+  []
+  (comp
+   (dev)
+   (gird :dev true :init-fn '<<project-ns>>.handler/init)
+   (war)
+   (target)))
+<% endif %>

--- a/resources/leiningen/new/luminus/core/src/core.clj
+++ b/resources/leiningen/new/luminus/core/src/core.clj
@@ -75,5 +75,6 @@
       (migrations/migrate args (select-keys env [:database-url]))
       (System/exit 0))
     :else
-    (start-app args)))
-  <% else %>(start-app args))<% endif %>
+    (start-app args))
+  <% else %>(start-app args)<% endif %><% if boot %>
+  @(promise))<% else %>)<% endif %>

--- a/src/leiningen/new/boot.clj
+++ b/src/leiningen/new/boot.clj
@@ -1,0 +1,25 @@
+(ns leiningen.new.boot
+  (:require [leiningen.new.common :refer :all]))
+
+(defn boot-features [[assets options :as state]]
+  (if (some #{"+boot"} (:features options))
+    [(conj assets ["build.boot" "core/build.boot"])
+     (let [new-opts (-> options
+                        (assoc :boot true)
+                        (update :source-paths set)
+                        (update :resource-paths set))]
+       (if (and (some #{"+war"} (:features options))
+                (some #{"+immutant"} (:features options)))
+         ;; There is a conflict with dependencies with ring webjars when
+         ;; org.webjars/webjars-locator-jboss-vfs is added, but only under
+         ;; boot. This removes the conflict
+         (let [web-jar-dep (first (filter #(= (first %) 'ring-webjars)
+                                          (:dependencies options)))
+               new-web-jar-dep (conj web-jar-dep :exclusions
+                                     ['org.webjars/webjars-locator-core])]
+           (assoc new-opts :dependencies
+                  (replace {web-jar-dep new-web-jar-dep}
+                           (:dependencies options))))
+         new-opts))]
+    state))
+

--- a/src/leiningen/new/cljs.clj
+++ b/src/leiningen/new/cljs.clj
@@ -1,5 +1,6 @@
 (ns leiningen.new.cljs
-  (:require [leiningen.new.common :refer :all]))
+  (:require [leiningen.new.common :refer :all]
+            [clojure.string :refer [join]]))
 
 (def cljs-assets
   [["src/cljs/{{sanitized}}/core.cljs" "cljs/src/cljs/core.cljs"]
@@ -12,6 +13,9 @@
    ["resources/templates/home.html" "cljs/templates/home.html"]
    ["resources/templates/error.html" "core/resources/templates/error.html"]])
 
+(def boot-cljs-assets
+  [["src/app.cljs.edn" "cljs/src/app.cljs.edn"]])
+
 (def cljs-version "1.9.854")
 
 (def figwheel-version "0.5.11")
@@ -21,6 +25,7 @@
 
 (def source-paths
   ["src/cljc"])
+;;NOTE: under boot, src/cljs is also added to source-paths (see boot-cljs-features)
 
 (def resource-paths
   ["target/cljsbuild"])
@@ -43,13 +48,18 @@
    ['figwheel-sidecar figwheel-version]
    ['com.cemerick/piggieback "0.2.2"]])
 
+(defn get-output-dir [features]
+  (if (some #{"+boot"} features)
+    ""
+    "target/cljsbuild/"))
+
 (defn uberjar-cljsbuild [features]
   {:builds
    {:min
     {:source-paths ["src/cljc" "src/cljs" "env/prod/cljs"]
      :compiler
      (merge
-       {:output-to "target/cljsbuild/public/js/app.js"
+       {:output-to (str (get-output-dir features) "public/js/app.js")
        :optimizations :advanced
        :pretty-print false
        :closure-warnings
@@ -57,7 +67,7 @@
        (when (some #{"+reagent" "+re-frame"} features)
          {:externs ["react/externs/react.js"]}))}}})
 
-(defn dev-cljsbuild [{:keys [project-ns]}]
+(defn dev-cljsbuild [{:keys [project-ns features]}]
   {:builds
    {:app
     {:source-paths ["src/cljs" "src/cljc" "env/dev/cljs"]
@@ -65,8 +75,8 @@
      :compiler
      {:main          (str project-ns ".app")
       :asset-path    "/js/out"
-      :output-to     "target/cljsbuild/public/js/app.js"
-      :output-dir    "target/cljsbuild/public/js/out"
+      :output-to     (str (get-output-dir features) "public/js/app.js")
+      :output-dir    (str (get-output-dir features) "public/js/out")
       :source-map    true
       :optimizations :none
       :pretty-print  true}}}})
@@ -92,26 +102,70 @@
      :nrepl-middleware `[cemerick.piggieback/wrap-cljs-repl
                          ~@(when cider? ['cider.nrepl/cider-middleware])]}))
 
+(defn cljs-lein-features [[assets options :as state]]
+  [assets
+   (-> options
+       (assoc
+        :dev-cljsbuild (indent dev-indent (dev-cljsbuild options))
+        :test-cljsbuild (indent dev-indent (test-cljsbuild options))
+        :uberjar-cljsbuild (indent uberjar-indent (uberjar-cljsbuild (:features options)))
+        :cljs-test cljs-test
+        :figwheel (indent root-indent (figwheel options))
+        :cljs-uberjar-prep ":prep-tasks [\"compile\" [\"cljsbuild\" \"once\" \"min\"]]")
+       (append-options :source-paths source-paths)
+       (append-options :resource-paths resource-paths))])
+
+;; Options for boot
+
+(def boot-cljs-assets
+  [["src/cljs/app.cljs.edn" "cljs/src/cljs/app.cljs.edn"]])
+
+(def cljs-boot-plugins '[[adzerk/boot-cljs "2.1.0-SNAPSHOT" :scope "test"]
+                         [crisptrutski/boot-cljs-test "0.3.2-SNAPSHOT" :scope "test"]
+                         [adzerk/boot-cljs-repl "0.3.3" :scope "test"]])
+
+(def cljs-boot-dev-plugins
+  '[[crisptrutski/boot-cljs-test "0.3.2-SNAPSHOT" :scope "test"]
+    [powerlaces/boot-figreload "0.1.1-SNAPSHOT" :scope "test"]
+    [org.clojure/clojurescript cljs-version :scope "test"]
+    [pandeiro/boot-http "0.7.6" :scope "test"]
+    [weasel "0.7.0" :scope "test"]
+    [org.clojure/tools.nrepl "0.2.12" :scope "test"]])
+
+(defn dev-cljs [options]
+  (let [lein-map (dev-cljsbuild options)
+        test-map (test-cljsbuild options)]
+    {:source-paths (join " " (map #(str "\"" % "\"")
+                                  (get-in lein-map [:builds :app :source-paths])))
+     :figwheel (get-in lein-map [:builds :app :figwheel])
+     :compiler (get-in lein-map [:builds :app :compiler])
+     :test {:source-paths (get-in test-map [:builds :test :source-paths])
+            :compiler (get-in test-map [:builds :test :compiler])}}))
+
+(defn cljs-boot-features [[assets options :as state]]
+  [(into assets boot-cljs-assets)
+   (-> options
+       (append-options :dependencies cljs-boot-plugins)
+       (append-options :dev-dependencies cljs-boot-dev-plugins)
+       (append-options :source-paths (conj source-paths "src/cljs"))
+       (assoc :dev-cljs (dev-cljs options)))])
+
 (defn cljs-features [[assets options :as state]]
   (if (some #{"+cljs"} (:features options))
-    [(into (remove-conflicting-assets assets ".html") cljs-assets)
-     (-> options
-         (update :dependencies
-                 #(remove (fn [[artifact]]
-                            (= artifact 'org.webjars/jquery)) %))
-         (append-options :dependencies cljs-dependencies)
-         (append-options :plugins cljs-plugins)
-         (append-options :source-paths source-paths)
-         (append-options :resource-paths resource-paths)
-         (append-options :dev-dependencies cljs-dev-dependencies)
-         (append-options :dev-plugins cljs-dev-plugins)
-         (update-in [:clean-targets] (fnil into []) clean-targets)
-         (assoc
-           :cljs true
-           :dev-cljsbuild (indent dev-indent (dev-cljsbuild options))
-           :test-cljsbuild (indent dev-indent (test-cljsbuild options))
-           :uberjar-cljsbuild (indent uberjar-indent (uberjar-cljsbuild (:features options)))
-           :cljs-test cljs-test
-           :figwheel (indent root-indent (figwheel options))
-           :cljs-uberjar-prep ":prep-tasks [\"compile\" [\"cljsbuild\" \"once\" \"min\"]]"))]
-    state))
+    (let [updated-state
+          [(into (remove-conflicting-assets assets ".html") cljs-assets)
+           (-> options
+               (update :dependencies
+                       #(remove (fn [[artifact]]
+                                  (= artifact 'org.webjars/jquery)) %))
+               (append-options :dependencies cljs-dependencies)
+               (append-options :plugins cljs-plugins)
+               (append-options :dev-dependencies cljs-dev-dependencies)
+               (append-options :dev-plugins cljs-dev-plugins)
+               (update-in [:clean-targets] (fnil into []) clean-targets)
+               (assoc :cljs true))]
+           boot? (some #{"+boot"} (:features options))]
+      (if boot?
+        (cljs-boot-features updated-state)
+        (cljs-lein-features updated-state)))
+      state))

--- a/src/leiningen/new/common.clj
+++ b/src/leiningen/new/common.clj
@@ -6,6 +6,7 @@
 
 (def dependency-indent 17)
 (def dev-dependency-indent 33)
+(def boot-dev-dependency-indent 30)
 (def plugin-indent 12)
 (def root-indent 2)
 (def dev-indent 18)

--- a/src/leiningen/new/cucumber.clj
+++ b/src/leiningen/new/cucumber.clj
@@ -8,16 +8,20 @@
 
 (defn cucumber-features [[assets options :as state]]
   (if (some #{"+cucumber"} (:features options))
-    [(into assets cucumber-assets)
-     (-> options
-         (append-options :plugins [['org.clojars.punkisdead/lein-cucumber "1.0.5"]])
-         (append-options :dev-dependencies [['org.clojure/core.cache "0.6.3"]
-                                            ['org.apache.httpcomponents/httpcore "4.4"]
-                                            ['clj-webdriver/clj-webdriver "0.7.2"]
-                                            (if (some #{"+auth" "+auth-jwe"} (:features options))
-                                              ['org.seleniumhq.selenium/selenium-server "2.48.2"
-                                               :exclusions ['org.bouncycastle/bcprov-jdk15on
-                                                            'org.bouncycastle/bcpkix-jdk15on]]
-                                              ['org.seleniumhq.selenium/selenium-server "2.48.2"])])
-         (assoc :cucumber-feature-paths (pprint-code ["test/clj/features"])))]
+    (do
+      (if (some #{"+boot"} (:features options))
+        (throw
+         (IllegalArgumentException. "+cucumber and +boot may not be used together.")))
+      [(into assets cucumber-assets)
+       (-> options
+           (append-options :plugins [['org.clojars.punkisdead/lein-cucumber "1.0.5"]])
+           (append-options :dev-dependencies [['org.clojure/core.cache "0.6.3"]
+                                              ['org.apache.httpcomponents/httpcore "4.4"]
+                                              ['clj-webdriver/clj-webdriver "0.7.2"]
+                                              (if (some #{"+auth" "+auth-jwe"} (:features options))
+                                                ['org.seleniumhq.selenium/selenium-server "2.48.2"
+                                                 :exclusions ['org.bouncycastle/bcprov-jdk15on
+                                                              'org.bouncycastle/bcpkix-jdk15on]]
+                                                ['org.seleniumhq.selenium/selenium-server "2.48.2"])])
+           (assoc :cucumber-feature-paths (pprint-code ["test/clj/features"])))])
     state))

--- a/src/leiningen/new/kibit.clj
+++ b/src/leiningen/new/kibit.clj
@@ -3,8 +3,16 @@
 
 (defn kibit-features [[assets options :as state]]
   (if (some #{"+kibit"} (:features options))
+    (let [boot? (some #{"+boot"} (:features options))
+          plugin-key (if boot?
+                       :dependencies
+                       :plugins)]
+    (if boot?
+      (println "Warning: kibit doesn't have native boot support and must be "
+               "called manually on the commandline."))
     [assets
      (-> options
-         (append-options :plugins [['lein-kibit "0.1.2"]]))]
+         (append-options plugin-key (if boot?
+                                      [['lein-kibit "0.1.2" :scope "test"]]
+                                      [['lein-kibit "0.1.2"]])))])
     state))
-

--- a/src/leiningen/new/lein.clj
+++ b/src/leiningen/new/lein.clj
@@ -1,0 +1,9 @@
+(ns leiningen.new.lein
+  (:require [leiningen.new.common :refer :all]))
+
+(defn lein-features [[assets options :as state]]
+  (if (some #{"+lein"} (:features options))
+    [(conj assets ["project.clj" "core/project.clj"])
+     options]
+    state))
+

--- a/src/leiningen/new/sassc.clj
+++ b/src/leiningen/new/sassc.clj
@@ -1,6 +1,8 @@
 (ns leiningen.new.sassc
   (:require [leiningen.new.common :refer :all]))
 
+;;On boot this can be run with the "sass" task.
+
 (def sassc-assets
   [["resources/scss/screen.scss" "sassc/resources/scss/screen.scss"]])
 
@@ -17,16 +19,24 @@
 
 (def sass-plugins
   [['lein-sassc "0.10.4"]
-   ['lein-auto "0.1.2"]])
+  ['lein-auto "0.1.2"]])
+
+(def boot-sass-plugins
+  '[[deraen/boot-sass "0.3.1" :scope "test"]])
 
 (defn sassc-features [[assets options :as state]]
   (if (some #{"+sassc"} (:features options))
-    [(into assets sassc-assets)
-     (-> options
-         (append-options :plugins sass-plugins)
-         (assoc :sassc-docs ((:selmer-renderer options)
-                              (slurp-resource "sassc/docs/sassc_instructions.md")
-                              options))
-         (assoc :sassc-config-params (unwrap-map (indent root-indent sassc-config)))
-         (assoc :sassc-auto-config (unwrap-map (indent root-indent sassc-auto-config))))]
+    (let [boot? (some #{"+boot"} (:features options))
+          plugin-key (if boot? :dependencies :plugins)]
+      [(into assets sassc-assets)
+       (-> options
+           (append-options plugin-key (if boot?
+                                        boot-sass-plugins
+                                        sass-plugins))
+           (assoc :sassc true)
+           (assoc :sassc-docs ((:selmer-renderer options)
+                               (slurp-resource "sassc/docs/sassc_instructions.md")
+                               options))
+           (assoc :sassc-config-params (unwrap-map (indent root-indent sassc-config)))
+           (assoc :sassc-auto-config (unwrap-map (indent root-indent sassc-auto-config))))])
     state))

--- a/src/leiningen/new/war.clj
+++ b/src/leiningen/new/war.clj
@@ -29,5 +29,6 @@
                                    (conj dependencies ['luminus/ring-ttl-session "0.3.1"]))))
          (append-options :dependencies [['ring/ring-servlet "1.4.0"]])
          (append-options :dev-dependencies [['directory-naming/naming-java "0.8"]])
-         (append-options :plugins [['lein-uberwar "0.2.0"]]))]
+         (append-options :plugins (if (some #{"+lein"} (:features options))
+                                    [['lein-uberwar "0.2.0"]])))]
     state))


### PR DESCRIPTION
Fixes #223.

To initiate such a project use the +boot profile.

Wherever possible, the boot template uses the same data as the lein template.
For example, all dependencies are pulled from the same option in the options
map.

The +cljs profile has been tested extensively, other profiles have not been
tested as conclusively but should work fine (most simply add assets and/or
dependencies, which boot and lein treat equally). The cucumber profile will fail if attempted to use with boot, since it uses a lein-only plugin. Kibit requires manual intervention to run with boot, and does yet have a pre-packaged task.

If creating the template using lein (without the +boot) profile, there should be no difference in behavior.