### PR TITLE
Adds missing file

### DIFF
--- a/resources/leiningen/new/luminus/cljs/src/cljs/app.cljs.edn
+++ b/resources/leiningen/new/luminus/cljs/src/cljs/app.cljs.edn
@@ -1,0 +1,2 @@
+{:require [<<sanitized>>.core]
+ :compiler-options <<dev-cljs.compiler>>}


### PR DESCRIPTION
Adds the app.cljs.edn file to avoid a "Template resource
'leiningen/new/luminus/cljs/src/cljs/app.cljs.edn' not found." error.