### PR TITLE
Fix tests and boot figwheel task

### DIFF
--- a/resources/leiningen/new/luminus/cljs/test/cljs/core_test.cljs
+++ b/resources/leiningen/new/luminus/cljs/test/cljs/core_test.cljs
@@ -1,7 +1,7 @@
 (ns <<project-ns>>.core-test
   (:require [cljs.test :refer-macros [is are deftest testing use-fixtures]]
-            [pjstadig.humane-test-output]
-            [reagent.core :as reagent :refer [atom]]
+            [pjstadig.humane-test-output]<% if reagent %>
+            [reagent.core :as reagent :refer [atom]]<% endif %>
             [<<project-ns>>.core :as rc]))
 
 (deftest test-home

--- a/resources/leiningen/new/luminus/core/build.boot
+++ b/resources/leiningen/new/luminus/core/build.boot
@@ -68,7 +68,7 @@
   (require '[powerlaces.boot-figreload :refer [reload]])
   (let [reload (resolve 'powerlaces.boot-figreload/reload)]
     (comp
-     (reload {:client-opts {:debug true}})
+     (reload :client-opts {:debug true})
      (cljs-repl)
      (cljs)
      (start-server)


### PR DESCRIPTION
Fixes an issue where a reagant import was included even when the reagent profile
was not added.

Also fixes an issue with bad arguments being passed to the cljs task in the
figwheel task (causing it to fail).