### PR TITLE
Fix typos in logback.xml configuration files.

### DIFF
--- a/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
@@ -24,20 +24,12 @@
             <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
         </encoder>
     </appender>
-    <logger name="org.apache.http" level="warn"></logger>
-    <logger name="org.xnio.nio" level="warn"></logger>
-    <% if relational-db %>
-    <logger name="com.zaxxer.hikari" level="warn"></logger>
-    <% endif %>
-    <% if cucumber-feature-paths %>
-    <logger name="com.mchange" level="warn"></logger>
-    <% endif %>
-    <% ifequal server "jetty" %>
-    <logger name="org.eclipse.jetty" level="warn"></logger>
-    <% endifequal %>
-    <% ifequal server "aleph" %>
-    <logger name="io.netty" level="warn"></logger>
-    <% endifequal %>
+    <logger name="org.apache.http" level="warn" />
+    <logger name="org.xnio.nio" level="warn" />
+    <% if relational-db %><logger name="com.zaxxer.hikari" level="warn" /><% endif %>
+    <% if cucumber-feature-paths %><logger name="com.mchange" level="warn" /><% endif %>
+    <% ifequal server "jetty" %><logger name="org.eclipse.jetty" level="warn" /><% endifequal %>
+    <% ifequal server "aleph" %><logger name="io.netty" level="warn" /><% endifequal %>
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />

--- a/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
@@ -25,28 +25,28 @@
         </encoder>
     </appender>
     <logger name="org.apache.http" level="warn">
-        <AppenderRef ref="STDOUT"/>
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
     </logger>
     <logger name="org.xnio.nio" level="warn">
-        <AppenderRef ref="STDOUT"/>
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
     </logger><% if relational-db %>
     <logger name="com.zaxxer.hikari" level="warn">
-        <AppenderRef ref="STDOUT"/>
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
     </logger><% endif %><% if cucumber-feature-paths %>
     <logger name="com.mchange" level="warn">
-        <AppenderRef ref="STDOUT"/>
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
     </logger><% endif %><% ifequal server "jetty" %>
     <logger name="org.eclipse.jetty" level="warn">
-        <AppenderRef ref="STDOUT"/>
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
     </logger><% endifequal %><% ifequal server "aleph" %>
     <logger name="io.netty" level="warn">
-        <AppenderRef ref="STDOUT"/>
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
     </logger><% endifequal %>
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />

--- a/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
@@ -24,30 +24,20 @@
             <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
         </encoder>
     </appender>
-    <logger name="org.apache.http" level="warn">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="org.xnio.nio" level="warn">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="FILE"/>
-    </logger><% if relational-db %>
-    <logger name="com.zaxxer.hikari" level="warn">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="FILE"/>
-    </logger><% endif %><% if cucumber-feature-paths %>
-    <logger name="com.mchange" level="warn">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="FILE"/>
-    </logger><% endif %><% ifequal server "jetty" %>
-    <logger name="org.eclipse.jetty" level="warn">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="FILE"/>
-    </logger><% endifequal %><% ifequal server "aleph" %>
-    <logger name="io.netty" level="warn">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="FILE"/>
-    </logger><% endifequal %>
+    <logger name="org.apache.http" level="warn"></logger>
+    <logger name="org.xnio.nio" level="warn"></logger>
+    <% if relational-db %>
+    <logger name="com.zaxxer.hikari" level="warn"></logger>
+    <% endif %>
+    <% if cucumber-feature-paths %>
+    <logger name="com.mchange" level="warn"></logger>
+    <% endif %>
+    <% ifequal server "jetty" %>
+    <logger name="org.eclipse.jetty" level="warn"></logger>
+    <% endifequal %>
+    <% ifequal server "aleph" %>
+    <logger name="io.netty" level="warn"></logger>
+    <% endifequal %>
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />

--- a/resources/leiningen/new/luminus/core/env/prod/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/prod/resources/logback.xml
@@ -16,24 +16,20 @@
             <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
         </encoder>
     </appender>
-    <logger name="org.apache.http" level="warn">
-        <appender-ref ref="FILE"/>
-    </logger>
-    <logger name="org.xnio.nio" level="warn">
-        <appender-ref ref="FILE"/>
-    </logger><% if relational-db %>
-    <logger name="com.zaxxer.hikari" level="warn">
-        <appender-ref ref="FILE"/>
-    </logger><% endif %><% if cucumber-feature-paths %>
-    <logger name="com.mchange" level="warn">
-        <appender-ref ref="FILE"/>
-    </logger><% endif %><% ifequal server "jetty" %>
-    <logger name="org.eclipse.jetty" level="warn">
-        <appender-ref ref="FILE"/>
-    </logger><% endifequal %><% ifequal server "aleph" %>
-    <logger name="io.netty" level="warn">
-        <appender-ref ref="FILE"/>
-    </logger><% endifequal %>
+    <logger name="org.apache.http" level="warn"></logger>
+    <logger name="org.xnio.nio" level="warn"></logger>
+    <% if relational-db %>
+    <logger name="com.zaxxer.hikari" level="warn"></logger>
+    <% endif %>
+    <% if cucumber-feature-paths %>
+    <logger name="com.mchange" level="warn"></logger>
+    <% endif %>
+    <% ifequal server "jetty" %>
+    <logger name="org.eclipse.jetty" level="warn"></logger>
+    <% endifequal %>
+    <% ifequal server "aleph" %>
+    <logger name="io.netty" level="warn"></logger>
+    <% endifequal %>
     <root level="INFO">
         <appender-ref ref="FILE" />
     </root>

--- a/resources/leiningen/new/luminus/core/env/prod/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/prod/resources/logback.xml
@@ -17,22 +17,22 @@
         </encoder>
     </appender>
     <logger name="org.apache.http" level="warn">
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="FILE"/>
     </logger>
     <logger name="org.xnio.nio" level="warn">
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="FILE"/>
     </logger><% if relational-db %>
     <logger name="com.zaxxer.hikari" level="warn">
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="FILE"/>
     </logger><% endif %><% if cucumber-feature-paths %>
     <logger name="com.mchange" level="warn">
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="FILE"/>
     </logger><% endif %><% ifequal server "jetty" %>
     <logger name="org.eclipse.jetty" level="warn">
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="FILE"/>
     </logger><% endifequal %><% ifequal server "aleph" %>
     <logger name="io.netty" level="warn">
-        <AppenderRef ref="FILE"/>
+        <appender-ref ref="FILE"/>
     </logger><% endifequal %>
     <root level="INFO">
         <appender-ref ref="FILE" />

--- a/resources/leiningen/new/luminus/core/env/prod/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/prod/resources/logback.xml
@@ -16,20 +16,12 @@
             <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg %n</pattern>
         </encoder>
     </appender>
-    <logger name="org.apache.http" level="warn"></logger>
-    <logger name="org.xnio.nio" level="warn"></logger>
-    <% if relational-db %>
-    <logger name="com.zaxxer.hikari" level="warn"></logger>
-    <% endif %>
-    <% if cucumber-feature-paths %>
-    <logger name="com.mchange" level="warn"></logger>
-    <% endif %>
-    <% ifequal server "jetty" %>
-    <logger name="org.eclipse.jetty" level="warn"></logger>
-    <% endifequal %>
-    <% ifequal server "aleph" %>
-    <logger name="io.netty" level="warn"></logger>
-    <% endifequal %>
+    <logger name="org.apache.http" level="warn" />
+    <logger name="org.xnio.nio" level="warn" />
+    <% if relational-db %><logger name="com.zaxxer.hikari" level="warn"/><% endif %>
+    <% if cucumber-feature-paths %><logger name="com.mchange" level="warn"/><% endif %>
+    <% ifequal server "jetty" %><logger name="org.eclipse.jetty" level="warn" /><% endifequal %>
+    <% ifequal server "aleph" %><logger name="io.netty" level="warn" /><% endifequal %>
     <root level="INFO">
         <appender-ref ref="FILE" />
     </root>


### PR DESCRIPTION
Correct syntax for logback loggers should be `<appender-ref>` elements instead of `<AppenderRef>`, which does not work. This can be checked with `<configuration debug="true">`

https://logback.qos.ch/manual/configuration.html