### PR TITLE
Update add-users-table.up.sql to use TIMESTAMP

### DIFF
--- a/resources/leiningen/new/luminus/db/migrations/add-users-table.up.sql
+++ b/resources/leiningen/new/luminus/db/migrations/add-users-table.up.sql
@@ -4,6 +4,6 @@ CREATE TABLE users
  last_name VARCHAR(30),
  email VARCHAR(30),
  admin BOOLEAN,
- last_login TIME,
+ last_login TIMESTAMP,
  is_active BOOLEAN,
  pass VARCHAR(300));


### PR DESCRIPTION
TIME has no date information, TIMESTAMP contains both date and time, which makes more sense in this case, I believe.