### PR TITLE
Added Lacinia as an available feature

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/lein-template "2.9.11.94"
+(defproject luminus/lein-template "2.9.11.95"
   :description "a template for creating Luminus applications"
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"

--- a/resources/leiningen/new/luminus/lacinia/resources/schema.edn
+++ b/resources/leiningen/new/luminus/lacinia/resources/schema.edn
@@ -1,0 +1,25 @@
+{:enums
+ {:episode
+  {:description "The episodes of the original Star Wars trilogy."
+   :values [:NEWHOPE :EMPIRE :JEDI]}}
+
+ :objects
+ {:droid
+  {:fields {:primary_functions {:type (list String)}
+            :id {:type Int}
+            :name {:type String}
+            :appears_in {:type (list :episode)}}}
+
+  :human
+  {:fields {:id {:type Int}
+            :name {:type String}
+            :home_planet {:type String}
+            :appears_in {:type (list :episode)}}}}
+
+ :queries
+ {:hero {:type (non-null :human)
+         :args {:id {:type String :default-value "2001"}}
+         :resolve :get-hero}
+  :droid {:type :droid
+          :args {:name {:type String}}
+          :resolve :get-droid}}}

--- a/resources/leiningen/new/luminus/lacinia/src/services.clj
+++ b/resources/leiningen/new/luminus/lacinia/src/services.clj
@@ -1,0 +1,68 @@
+(ns <<project-ns>>.routes.services
+  (:require [com.walmartlabs.lacinia.util :refer [attach-resolvers]]
+            [com.walmartlabs.lacinia.schema :as schema :refer [compile]]
+            [com.walmartlabs.lacinia :as lacinia :refer [execute]]
+            [clojure.data.json :as json]
+            [clojure.edn :as edn] 
+            [ring.util.http-response :refer :all]
+            [compojure.api.sweet :refer :all]<% if auth %>
+            [compojure.api.meta :refer [restructure-param]]
+            [buddy.auth.accessrules :refer [restrict]]
+            [buddy.auth :refer [authenticated?]]<% endif %>))
+
+<% if auth %>
+(defn access-error [_ _]
+  (unauthorized {:error "unauthorized"}))
+
+(defn wrap-restricted [handler rule]
+  (restrict handler {:handler  rule
+                     :on-error access-error}))
+
+(defmethod restructure-param :auth-rules
+  [_ rule acc]
+  (update-in acc [:middleware] conj [wrap-restricted rule]))
+
+(defmethod restructure-param :current-user
+  [_ binding acc]
+  (update-in acc [:letks] into [binding `(:identity ~'+compojure-api-request+)]))
+<% endif %>
+
+(defn get-hero [context args value]
+  (let [data  [{:id 1000
+               :name "Luke"
+               :home_planet "Tatooine"
+               :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]}
+              {:id 2000
+               :name "Lando Calrissian"
+               :home_planet "Socorro"
+               :appears_in ["EMPIRE" "JEDI"]}]]
+           (first data)))
+
+(def compiled-schema
+  (-> "resources/schema.edn"
+      slurp
+      edn/read-string
+      (attach-resolvers {:get-hero get-hero 
+                         :get-droid (constantly {})})
+      schema/compile))
+
+(defn format-params [query]
+   (let [parsed (json/read-str query)] ;;-> placeholder - need to ensure query meets graphql syntax
+     (str "query { hero(id: \"1000\") { name appears_in }}")))
+
+(defn execute-request [query]
+    (let [formatted (format-params query)
+          vars nil
+          context nil]
+    (-> (lacinia/execute compiled-schema formatted vars context)
+        (json/write-str))))
+
+(defapi service-routes
+ <% if auth %>
+  (GET "/authenticated" []
+       :auth-rules authenticated?
+       :current-user user
+       (ok {:user user}))<% endif %>
+                        
+  (POST "/api" [query]
+      (ok (execute-request query))))

--- a/src/leiningen/new/lacinia.clj
+++ b/src/leiningen/new/lacinia.clj
@@ -1,0 +1,49 @@
+(ns leiningen.new.lacinia
+  (:require [leiningen.new.common :refer :all]))
+
+(def conflicting-assets
+  ["layout.clj"
+   "home.clj"
+   "screen.css"
+   "luminus.png"
+   "docs.md"
+   ".html"])
+
+(def conflicting-features
+  #{"+swagger"})
+
+(def lacinia-assets
+  [["src/clj/{{sanitized}}/routes/services.clj" "lacinia/src/services.clj"]
+   ["resources/schema.edn" "lacinia/resources/schema.edn"]])
+
+(def lacinia-dependencies
+  [['metosin/compojure-api "1.1.11"]
+   ['com.walmartlabs/lacinia "0.21.0"]])
+
+(def required-features
+  [])
+
+(defn update-features [features]
+  (-> features
+      (clojure.set/difference conflicting-features)
+      (into required-features)))
+
+(defn update-assets [assets]
+  (reduce #(remove-conflicting-assets %1 %2) assets conflicting-assets))
+
+(defn lacinia-features [[assets options :as state]]
+  (if (some #{"+lacinia"} (:features options))
+    (do
+      (when-let [conflicts (not-empty (clojure.set/intersection conflicting-features (:features options)))]
+        (println "ignoring conflicting features" (clojure.string/join ", " conflicts)))
+      [(into assets lacinia-assets)
+       (-> options
+           (append-options :dependencies lacinia-dependencies)
+           (update :features update-features)
+           (assoc :lacinia true
+                  :service-required
+                    (indent require-indent
+                        [[(symbol (str (:project-ns options) ".routes.services")) :refer ['service-routes]]])
+                   :service-routes
+                    (indent dev-indent ["#'service-routes"])))])
+    state))

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -23,6 +23,7 @@
             [leiningen.new.http-kit-luminus :refer [http-kit-features]]
             [leiningen.new.immutant :refer [immutant-features]]
             [leiningen.new.swagger :refer [swagger-features]]
+            [leiningen.new.lacinia :refer [lacinia-features]]
             [leiningen.new.sassc :refer [sassc-features]]
             [leiningen.new.site :refer [site-features]]
             [leiningen.new.war :refer [war-features]]
@@ -142,6 +143,7 @@
             reagent-features
             re-frame-features
             swagger-features
+            lacinia-features
             aleph-features
             jetty-features
             http-kit-features
@@ -207,7 +209,7 @@
                              ;;misc
                              "+cljs" "+hoplon" "+reagent" "+re-frame" "+auth" "+auth-jwe" "+site"
                              "+cucumber" "+sassc" "+cider" "+oauth"
-                             "+swagger" "+war"
+                             "+swagger" "+war" "+lacinia"
                              "+kibit" "+service"
                              "+boot"}
         options {:name              (project-name name)


### PR DESCRIPTION
This pull request adds a bare-bones example of Lacinia as an available template. 

I'm not sure best practice for integration with `compojure-api`, so I simplified the endpoint, which requires a POST with a query param. 

Otherwise, it is essentially a drop-in replacement for `swagger`.

Thanks for the great template, and please let me know if there's anything that needs to be changed...