### PR TITLE
Use a consistent style in HugSQL doc comments

### DIFF
--- a/resources/leiningen/new/luminus/db/sql/queries.sql
+++ b/resources/leiningen/new/luminus/db/sql/queries.sql
@@ -5,17 +5,17 @@ INSERT INTO users
 VALUES (:id, :first_name, :last_name, :email, :pass)
 
 -- :name update-user! :! :n
--- :doc update an existing user record
+-- :doc updates an existing user record
 UPDATE users
 SET first_name = :first_name, last_name = :last_name, email = :email
 WHERE id = :id
 
 -- :name get-user :? :1
--- :doc retrieve a user given the id.
+-- :doc retrieves a user record given the id
 SELECT * FROM users
 WHERE id = :id
 
 -- :name delete-user! :! :n
--- :doc delete a user given the id
+-- :doc deletes a user record given the id
 DELETE FROM users
 WHERE id = :id


### PR DESCRIPTION
Hi!

While working through your book, I came across this small discrepancy between the wording of the HugSQL documentation metadata comments. I hope this makes the template ever so slightly better!

Cheers,
Bojan

P.S. The other variant would be to write "user" everywhere (instead of "user record"). Maybe that would be nicer?