### PR TITLE
Relative path profile - refactoring to configurable variables

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/lein-template "2.9.11.98"
+(defproject luminus/lein-template "2.9.11.99"
   :description "a template for creating Luminus applications"
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"

--- a/src/leiningen/new/cucumber.clj
+++ b/src/leiningen/new/cucumber.clj
@@ -2,9 +2,9 @@
   (:require [leiningen.new.common :refer :all]))
 
 (def cucumber-assets
-  [["test/clj/{{sanitized}}/browser.clj" "cucumber/src/browser.clj"]
-   ["test/clj/features/step_definitions/home_page_steps.clj" "cucumber/src/home_page_steps.clj"]
-   ["test/clj/features/index_page.feature" "cucumber/resources/index_page.feature"]])
+  [["{{backend-test-path}}/{{sanitized}}/browser.clj" "cucumber/src/browser.clj"]
+   ["{{backedn-test-path}}/features/step_definitions/home_page_steps.clj" "cucumber/src/home_page_steps.clj"]
+   ["{{backend-test-path}}/features/index_page.feature" "cucumber/resources/index_page.feature"]])
 
 (defn cucumber-features [[assets options :as state]]
   (if (some #{"+cucumber"} (:features options))
@@ -23,5 +23,5 @@
                                                  :exclusions ['org.bouncycastle/bcprov-jdk15on
                                                               'org.bouncycastle/bcpkix-jdk15on]]
                                                 ['org.seleniumhq.selenium/selenium-server "2.48.2"])])
-           (assoc :cucumber-feature-paths (pprint-code ["test/clj/features"])))])
+           (assoc :cucumber-feature-paths (pprint-code ["{{backend-test-path}}/features"])))])
     state))

--- a/src/leiningen/new/db.clj
+++ b/src/leiningen/new/db.clj
@@ -34,21 +34,21 @@
   (let [timestamp (.format
                     (java.text.SimpleDateFormat. "yyyyMMddHHmmss")
                     (java.util.Date.))]
-    [["src/clj/{{sanitized}}/db/core.clj" "db/src/sql.db.clj"]
-     ["resources/sql/queries.sql" "db/sql/queries.sql"]
-     ["test/clj/{{sanitized}}/test/db/core.clj" "db/test/db/core.clj"]
-     [(str "resources/migrations/" timestamp "-add-users-table.up.sql") "db/migrations/add-users-table.up.sql"]
-     [(str "resources/migrations/" timestamp "-add-users-table.down.sql") "db/migrations/add-users-table.down.sql"]]))
+    [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/sql.db.clj"]
+     ["{{resource-path}}/sql/queries.sql" "db/sql/queries.sql"]
+     ["{{backend-test-path}}/{{sanitized}}/test/db/core.clj" "db/test/db/core.clj"]
+     [(str "{{resource-path}}/migrations/" timestamp "-add-users-table.up.sql") "db/migrations/add-users-table.up.sql"]
+     [(str "{{resource-path}}/migrations/" timestamp "-add-users-table.down.sql") "db/migrations/add-users-table.down.sql"]]))
 
 (defn db-profiles [options]
   {:database-profile-dev  (str :database-url " \"" (db-url options "dev") "\"")
    :database-profile-test (str :database-url " \"" (db-url options "test") "\"")})
 
 (def mongo-files
-  [["src/clj/{{sanitized}}/db/core.clj" "db/src/mongodb.clj"]])
+  [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/mongodb.clj"]])
 
 (def datomic-files
-  [["src/clj/{{sanitized}}/db/core.clj" "db/src/datomic.clj"]])
+  [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/datomic.clj"]])
 
 (defn add-mongo [[assets options]]
   [(into assets mongo-files)

--- a/src/leiningen/new/graphql.clj
+++ b/src/leiningen/new/graphql.clj
@@ -8,9 +8,9 @@
   #{"+swagger"})
 
 (def graphql-assets
-  [["src/clj/{{sanitized}}/routes/services.clj" "graphql/src/services.clj"]
-   ["resources/templates/graphiql.html" "graphql/resources/graphiql.html"]
-   ["resources/graphql/schema.edn" "graphql/resources/schema.edn"]])
+  [["{{backend-path}}/{{sanitized}}/routes/services.clj" "graphql/src/services.clj"]
+   ["{{resource-path}}/templates/graphiql.html" "graphql/resources/graphiql.html"]
+   ["{{resource-path}}/graphql/schema.edn" "graphql/resources/schema.edn"]])
 
 (def graphql-dependencies
   [['metosin/compojure-api "1.1.11"]

--- a/src/leiningen/new/hoplon.clj
+++ b/src/leiningen/new/hoplon.clj
@@ -2,8 +2,8 @@
   (:require [leiningen.new.common :refer :all]))
 
 (def hoplon-assets
-  [["src/cljs/{{sanitized}}/core.cljs" "hoplon/src/cljs/core.cljs"]
-   ["src/cljs/{{sanitized}}/ajax.cljs" "hoplon/src/cljs/ajax.cljs"]])
+  [["{{client-path}}/{{sanitized}}/core.cljs" "hoplon/src/cljs/core.cljs"]
+   ["{{client-path}}/{{sanitized}}/ajax.cljs" "hoplon/src/cljs/ajax.cljs"]])
 
 (def hoplon-dependencies
   [['hoplon "7.0.3"]

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -54,31 +54,40 @@
 
    ;; core namespaces
    ["env/dev/clj/user.clj" "core/env/dev/clj/user.clj"]
-   ["src/clj/{{sanitized}}/core.clj" "core/src/core.clj"]
-   ["src/clj/{{sanitized}}/config.clj" "core/src/config.clj"]
-   ["src/clj/{{sanitized}}/handler.clj" "core/src/handler.clj"]
-   ["src/clj/{{sanitized}}/routes/home.clj" "core/src/home.clj"]
-   ["src/clj/{{sanitized}}/layout.clj" "core/src/layout.clj"]
-   ["src/clj/{{sanitized}}/middleware.clj" "core/src/middleware.clj"]
+   ["{{backend-path}}/{{sanitized}}/core.clj" "core/src/core.clj"]
+   ["{{backend-path}}/{{sanitized}}/config.clj" "core/src/config.clj"]
+   ["{{backend-path}}/{{sanitized}}/handler.clj" "core/src/handler.clj"]
+   ["{{backend-path}}/{{sanitized}}/routes/home.clj" "core/src/home.clj"]
+   ["{{backend-path}}/{{sanitized}}/layout.clj" "core/src/layout.clj"]
+   ["{{backend-path}}/{{sanitized}}/middleware.clj" "core/src/middleware.clj"]
 
    ;;HTML templates
-   ["resources/templates/base.html" "core/resources/templates/base.html"]
-   ["resources/templates/home.html" "core/resources/templates/home.html"]
-   ["resources/templates/about.html" "core/resources/templates/about.html"]
-   ["resources/templates/error.html" "core/resources/templates/error.html"]
+   ["{{resource-path}}/templates/base.html" "core/resources/templates/base.html"]
+   ["{{resource-path}}/templates/home.html" "core/resources/templates/home.html"]
+   ["{{resource-path}}/templates/about.html" "core/resources/templates/about.html"]
+   ["{{resource-path}}/templates/error.html" "core/resources/templates/error.html"]
 
    ;; public resources, example URL: /css/screen.css
-   ["resources/public/css/screen.css" "core/resources/css/screen.css"]
-   ["resources/docs/docs.md" "core/resources/docs.md"]
-   "resources/public/js"
+   ["{{resource-path}}/public/css/screen.css" "core/resources/css/screen.css"]
+   ["{{resource-path}}/docs/docs.md" "core/resources/docs.md"]
+   "{{resource-path}}/public/js"
 
    ;; tests
-   ["test/clj/{{sanitized}}/test/handler.clj" "core/test/handler.clj"]])
+   ["{{backend-test-path}}/{{sanitized}}/test/handler.clj" "core/test/handler.clj"]])
 
 (def binary-assets
-  [["resources/public/favicon.ico" "core/resources/favicon.ico"]
-   ["resources/public/img/warning_clojure.png" "core/resources/img/warning_clojure.png"]])
+  [["{{resource-path}}/public/favicon.ico" "core/resources/favicon.ico"]
+   ["{{resource-path}}/public/img/warning_clojure.png" "core/resources/img/warning_clojure.png"]])
 
+(def project-relative-paths
+  {:default       {:backend "src/clj"
+                   :backend-test "test/clj"
+                   :client "src/cljs"
+                   :client-test "test/cljs"
+                   :resource-path "resources"
+                   :cljc-path "src/cljc"
+                   :db     "src/clj"}})
+   
 (defn sort-deps [deps]
   (sort-by (fn [dep] (str dep)) deps))
 
@@ -198,6 +207,9 @@
       (and (= x1 x2) (< y1 y2))
       (and (= x1 x2) (= y1 y2) (< z1 z2)))))
 
+(defn get-relative-path-profile [feature-params]
+  (:default project-relative-paths))
+
 (defn luminus
   "Create a new Luminus project"
   [name & feature-params]
@@ -210,18 +222,29 @@
                              "+cljs" "+hoplon" "+reagent" "+re-frame" "+auth" "+auth-jwe" "+site"
                              "+cucumber" "+sassc" "+cider" "+oauth"
                              "+swagger" "+war" "+graphql"
-                             "+kibit" "+service"
+                             "+kibit" "+service" 
                              "+boot"}
+        {:keys [backend backend-test 
+                client client-test
+                db cljc-path
+                resource-path]}     (get-relative-path-profile feature-params)
         options {:name              (project-name name)
                  :dependencies      core-dependencies
                  :selmer-renderer   render-template
                  :min-lein-version  "2.0.0"
                  :project-ns        (sanitize-ns name)
                  :sanitized         (name-to-path name)
+                 :backend-path      backend
+                 :backend-test-path backend-test
+                 :client-path       client 
+                 :client-test-path  client-test 
+                 :db-path           db
+                 :cljc-path         cljc-path 
+                 :resource-path     resource-path
                  :year              (year)
                  :features          (set feature-params)
-                 :source-paths      ["src/clj"]
-                 :resource-paths    ["resources"]}
+                 :source-paths      [backend]
+                 :resource-paths    [resource-path]}
         unsupported (-> (set feature-params)
                         (clojure.set/difference supported-features)
                         (not-empty))]

--- a/src/leiningen/new/oauth.clj
+++ b/src/leiningen/new/oauth.clj
@@ -2,8 +2,8 @@
   (:require [leiningen.new.common :refer :all]))
 
 (def oauth-assets
-  [["src/clj/{{sanitized}}/oauth.clj" "oauth/src/oauth.clj"]
-   ["src/clj/{{sanitized}}/routes/oauth.clj" "oauth/src/routes.clj"]])
+  [["{{backend-path}}/{{sanitized}}/oauth.clj" "oauth/src/oauth.clj"]
+   ["{{backend-path}}/{{sanitized}}/routes/oauth.clj" "oauth/src/routes.clj"]])
 
 (defn oauth-features [[assets options :as state]]
   (if (some #{"+oauth"} (:features options))

--- a/src/leiningen/new/re_frame.clj
+++ b/src/leiningen/new/re_frame.clj
@@ -2,9 +2,9 @@
   (:require [leiningen.new.common :refer :all]))
 
 (def re-frame-assets
-  [["src/cljs/{{sanitized}}/core.cljs" "reframe/src/cljs/core.cljs"]
-   ["src/cljs/{{sanitized}}/db.cljs" "reframe/src/cljs/db.cljs"]
-   ["src/cljs/{{sanitized}}/events.cljs" "reframe/src/cljs/events.cljs"]])
+  [["{{client-path}}/{{sanitized}}/core.cljs" "reframe/src/cljs/core.cljs"]
+   ["{{client-path}}/{{sanitized}}/db.cljs" "reframe/src/cljs/db.cljs"]
+   ["{{client-path}}/{{sanitized}}/events.cljs" "reframe/src/cljs/events.cljs"]])
 
 (defn re-frame-features [[assets options :as state]]
   (if (some #{"+re-frame"} (:features options))

--- a/src/leiningen/new/reagent.clj
+++ b/src/leiningen/new/reagent.clj
@@ -2,8 +2,8 @@
   (:require [leiningen.new.common :refer :all]))
 
 (def reagent-assets
-  [["src/cljs/{{sanitized}}/core.cljs" "reagent/src/cljs/core.cljs"]
-   ["src/cljs/{{sanitized}}/ajax.cljs" "reagent/src/cljs/ajax.cljs"]])
+  [["{{client-path}}/{{sanitized}}/core.cljs" "reagent/src/cljs/core.cljs"]
+   ["{{client-path}}/{{sanitized}}/ajax.cljs" "reagent/src/cljs/ajax.cljs"]])
 
 (def reagent-dependencies
   [['reagent "0.7.0"]

--- a/src/leiningen/new/sassc.clj
+++ b/src/leiningen/new/sassc.clj
@@ -4,18 +4,18 @@
 ;;On boot this can be run with the "sass" task.
 
 (def sassc-assets
-  [["resources/scss/screen.scss" "sassc/resources/scss/screen.scss"]])
+  [["{{resource-path}}/scss/screen.scss" "sassc/resources/scss/screen.scss"]])
 
 (def sassc-config
   {:sassc
-   [{:src         "resources/scss/screen.scss"
-     :output-to   "resources/public/css/screen.css"
+   [{:src         "{{resource-path}}/scss/screen.scss"
+     :output-to   "{{resource-path}}/public/css/screen.css"
      :style       "nested"
-     :import-path "resources/scss"}]})
+     :import-path "{{resource-path}}/scss"}]})
 
 (def sassc-auto-config
   {:auto {"sassc" {:file-pattern  #"\.(scss|sass)$"
-                   :paths ["resources/scss"]}}})
+                   :paths ["{{resource-path}}/scss"]}}})
 
 (def sass-plugins
   [['lein-sassc "0.10.4"]

--- a/src/leiningen/new/swagger.clj
+++ b/src/leiningen/new/swagger.clj
@@ -2,7 +2,7 @@
   (:require [leiningen.new.common :refer :all]))
 
 (def swagger-assets
-  [["src/clj/{{sanitized}}/routes/services.clj" "swagger/src/services.clj"]])
+  [["{{backend-path}}/{{sanitized}}/routes/services.clj" "swagger/src/services.clj"]])
 
 (def swagger-dependencies
   [['metosin/compojure-api "1.1.11"]])


### PR DESCRIPTION
This sets the generated path as a template param which can be configurable in `luminus.clj` (at this point simply set to `:default`). 

The rationale for this would be the ability to add additional profiles to the template that would allow different project structures (think Docker services, for example). 

That said, perhaps it is too much overhead, so I will defer to you if you think it is useful or not. Thanks for the great template...