### PR TITLE
Add the graphiql endpoint when cljs is mounted

### DIFF
--- a/resources/leiningen/new/luminus/core/src/home.clj
+++ b/resources/leiningen/new/luminus/core/src/home.clj
@@ -9,7 +9,8 @@
 
 (defroutes home-routes
   (GET "/" []
-       (home-page))
+       (home-page))<% if graphql %>
+  (GET "/graphiql" [] (layout/render "graphiql.html"))<% endif %>
   (GET "/docs" []
        (-> (response/ok (-> "docs/docs.md" io/resource slurp))
            (response/header "Content-Type" "text/plain; charset=utf-8"))))


### PR DESCRIPTION
I noticed graphiql wasn't served when cljs was mounted, but seems like cljs apps should get graphiql too when they +graphql. One could argue you'd want to do it in the SPA but I'm not sure that's necessary, as it's definitely intended as a devtool rather than a for-public-consumption endpoint.