### PR TITLE
Procfile: Remove invalid env var

### DIFF
--- a/resources/leiningen/new/luminus/core/Procfile
+++ b/resources/leiningen/new/luminus/core/Procfile
@@ -1,1 +1,1 @@
-web: java $JVM_OPTS -cp target/uberjar/<<name>>.jar clojure.main -m <<project-ns>>.core
+web: java -cp target/uberjar/<<name>>.jar clojure.main -m <<project-ns>>.core


### PR DESCRIPTION
With the latest AWS Elastic Beanstalk running supervisor 3.2 this fails - `$JVM_OPTS` is passed literally to the java command, which fails trying to load a class of that name. 

According to the [Supervisor docs](http://supervisord.org/configuration.html#environment-variables), it should use the syntax `%(ENV_JVM_OPTS)s`. However that fails too with:

> ERROR: CANT_REREAD: Format string 'env java %(ENV_JVM_OPTS)s -cp target/uberjar/myapp.jar clojure.main -m myapp.core' for 'program:application-web-1.command' contains names ('ENV_JVM_OPTS') which cannot be expanded. Available names: ENV_PATH, ENV_TERM, ENV_UPSTART_INSTANCE, ENV_UPSTART_JOB, group_name, here, host_node_name, process_num, program_name in section 'program:application-web-1' (file: '/etc/supervisor/conf.d/application.conf')

I assume it would work if I added the env variable `JVM_OPTS` to the Beanstalk environment, e.g. via the AWS Console. Without it, it crashes. (I.e. does not handle a missing variable)