### PR TITLE
Fix log/error to get both params it expects

### DIFF
--- a/resources/leiningen/new/luminus/core/src/middleware.clj
+++ b/resources/leiningen/new/luminus/core/src/middleware.clj
@@ -41,7 +41,7 @@
     (try
       (handler req)
       (catch Throwable t
-        (log/error t)
+        (log/error t (.getMessage t))
         (error-page {:status 500
                      :title "Something very bad has happened!"
                      :message "We've dispatched a team of highly trained gnomes to take care of the problem."})))))


### PR DESCRIPTION
The signature is `[message]` pr `[throwable message]`; if we only send in `t` then it will be turned into `(str t)` and we loose the stacktrace & all.