### PR TITLE
Update cider-nrepl to 0.15.1

### DIFF
--- a/src/leiningen/new/cider.clj
+++ b/src/leiningen/new/cider.clj
@@ -6,5 +6,5 @@
     [assets
      (-> options
          (assoc :cider true)
-         (append-options :dependencies [['cider/cider-nrepl "0.15.0-SNAPSHOT"]]))]
+         (append-options :dependencies [['cider/cider-nrepl "0.15.1"]]))]
     state))


### PR DESCRIPTION
Application did not start with 0.15.0 because of:
java.lang.ExceptionInInitializerError >> Invalid token ::clojure.test/once-fixtures

Maybe this is related: clojure-emacs/cider#2081