### PR TITLE
Adds migratus support for boot

### DIFF
--- a/resources/leiningen/new/luminus/core/build.boot
+++ b/resources/leiningen/new/luminus/core/build.boot
@@ -2,6 +2,9 @@
  :dependencies '[<<dependencies>>]<% if resource-paths %>
  :source-paths <<source-paths>>
  :resource-paths <<resource-paths>><% endif %>)
+
+(require '[adzerk.boot-test :refer [test]]
+         '[luminus.boot-cprop :refer [cprop]])
 <% if cljs %>
 (require '[adzerk.boot-cljs :refer [cljs]]
          '[adzerk.boot-cljs-repl :refer [cljs-repl]])
@@ -24,7 +27,7 @@
   (require 'pjstadig.humane-test-output)
   (let [pja (resolve 'pjstadig.humane-test-output/activate!)]
     (pja))
-  identity)
+  (cprop :profile :profiles/dev))
 
 (deftask testing
   "Enables configuration for testing."
@@ -32,14 +35,14 @@
   (dev)
   (set-env! :resource-paths #(conj % "env/test/resources"))<% if cljs %>
   (merge-env! :source-paths <<dev-cljs.test.source-paths>>)<% endif %>
-  identity)
+  (cprop :profile :profiles/test))
 
 (deftask prod
   "Enables configuration for production building."
   []
   (merge-env! :source-paths #{"env/prod/clj"<% if cljs %> "env/prod/cljs"<% endif %>}
               :resource-paths #{"env/prod/resources"})
-  identity)
+  (cprop :profile :profiles/prod))
 
 (deftask start-server
   "Runs the project without building class files.
@@ -56,7 +59,7 @@
   "Starts the server and causes it to wait."
   []
   (comp
-   (start-server)
+   (apply start-server *args*)
    (wait)))
 <% if cljs %>
 (require '[clojure.java.io :as io])

--- a/resources/leiningen/new/luminus/core/src/core.clj
+++ b/resources/leiningen/new/luminus/core/src/core.clj
@@ -76,6 +76,5 @@
       (migrations/migrate args (select-keys env [:database-url]))
       (System/exit 0))
     :else
-    (start-app args))
-  <% else %>(start-app args)<% endif %><% if boot %>
-  @(promise))<% else %>)<% endif %>
+    (start-app args)))
+  <% else %>(start-app args))<% endif %>

--- a/src/leiningen/new/boot.clj
+++ b/src/leiningen/new/boot.clj
@@ -1,13 +1,17 @@
 (ns leiningen.new.boot
   (:require [leiningen.new.common :refer :all]))
 
+(def boot-dependencies '[[adzerk/boot-test "1.2.0" :scope "test"]
+                         [luminus/boot-cprop "1.0.0" :scope "test"]])
+
 (defn boot-features [[assets options :as state]]
   (if (some #{"+boot"} (:features options))
     [(conj assets ["build.boot" "core/build.boot"])
      (let [new-opts (-> options
                         (assoc :boot true)
                         (update :source-paths set)
-                        (update :resource-paths set))]
+                        (update :resource-paths set)
+                        (append-options :dependencies boot-dependencies))]
        (if (and (some #{"+war"} (:features options))
                 (some #{"+immutant"} (:features options)))
          ;; There is a conflict with dependencies with ring webjars when

--- a/src/leiningen/new/cljs.clj
+++ b/src/leiningen/new/cljs.clj
@@ -130,7 +130,6 @@
   '[[crisptrutski/boot-cljs-test "0.3.2-SNAPSHOT" :scope "test"]
     [powerlaces/boot-figreload "0.1.1-SNAPSHOT" :scope "test"]
     [org.clojure/clojurescript cljs-version :scope "test"]
-    [pandeiro/boot-http "0.7.6" :scope "test"]
     [weasel "0.7.0" :scope "test"]
     [org.clojure/tools.nrepl "0.2.12" :scope "test"]])
 


### PR DESCRIPTION
Uses the boot migratus plugin and environ to set variables.

One can migrate by using "boot dev migratus". See "boot migratus -h" for more
information.

This should mean databases are fully supported under boot.