### PR TITLE
make `:init-ns` as `<<name>>.core` instead of `user`

### DIFF
--- a/resources/leiningen/new/luminus/core/project.clj
+++ b/resources/leiningen/new/luminus/core/project.clj
@@ -50,7 +50,7 @@
                   :doo <<cljs-test>><% endif %>
                   :source-paths ["env/dev/clj"]
                   :resource-paths ["env/dev/resources"]
-                  :repl-options {:init-ns user}
+                  :repl-options {:init-ns <<name>>.core}
                   :injections [(require 'pjstadig.humane-test-output)
                                (pjstadig.humane-test-output/activate!)]}
    :project/test {:jvm-opts ["-server" "-Dconf=test-config.edn"]


### PR DESCRIPTION
to make it slightly easier when starting repl and invoking `(-main)`
without the need to change namespace first