### PR TITLE
Support migratus with boot and remove references to boot cprop

### DIFF
--- a/resources/leiningen/new/luminus/core/build.boot
+++ b/resources/leiningen/new/luminus/core/build.boot
@@ -27,7 +27,8 @@
   (require 'pjstadig.humane-test-output)
   (let [pja (resolve 'pjstadig.humane-test-output/activate!)]
     (pja))
-  (cprop :profile :profiles/dev))
+  (.. System (getProperties) (setProperty "conf" "dev-config.edn"))
+  identity)
 
 (deftask testing
   "Enables configuration for testing."
@@ -35,14 +36,15 @@
   (dev)
   (set-env! :resource-paths #(conj % "env/test/resources"))<% if cljs %>
   (merge-env! :source-paths <<dev-cljs.test.source-paths>>)<% endif %>
-  (cprop :profile :profiles/test))
+  (.. System (getProperties) (setProperty "conf" "test-config.edn"))
+  identity)
 
 (deftask prod
   "Enables configuration for production building."
   []
   (merge-env! :source-paths #{"env/prod/clj"<% if cljs %> "env/prod/cljs"<% endif %>}
               :resource-paths #{"env/prod/resources"})
-  (cprop :profile :profiles/prod))
+  identity)
 
 (deftask start-server
   "Runs the project without building class files.

--- a/resources/leiningen/new/luminus/core/build.boot
+++ b/resources/leiningen/new/luminus/core/build.boot
@@ -2,14 +2,17 @@
  :dependencies '[<<dependencies>>]<% if resource-paths %>
  :source-paths <<source-paths>>
  :resource-paths <<resource-paths>><% endif %>)
-
-(require '[adzerk.boot-test :refer [test]]
-         '[luminus.boot-cprop :refer [cprop]])
+(require '[clojure.java.io :as io]
+         '[clojure.edn :as edn]
+         '[adzerk.boot-test :refer [test]])
 <% if cljs %>
 (require '[adzerk.boot-cljs :refer [cljs]]
          '[adzerk.boot-cljs-repl :refer [cljs-repl]])
 <% endif %><% if sassc-config-params %>
 (require '[deraen.boot-sass :refer [sass]])
+<% endif %>
+<% if migrations %>
+(require '[luminus.boot-migratus :refer [migratus]])
 <% endif %>
 (deftask dev
   "Enables configuration for a development setup."
@@ -23,7 +26,6 @@
                               <<dev-http-server-dependencies>><% endif %>
                               [pjstadig/humane-test-output "0.8.2"]<% if dev-dependencies %>
                               <<dev-dependencies>><% endif %>]))
-  (task-options! repl {:init-ns 'user})
   (require 'pjstadig.humane-test-output)
   (let [pja (resolve 'pjstadig.humane-test-output/activate!)]
     (pja))
@@ -53,9 +55,9 @@
   task."
   []
   (require '<<project-ns>>.core)
-  (let [start-app (resolve '<<project-ns>>.core/start-app)]
+  (let [-main (resolve '<<project-ns>>.core/-main)]
     (with-pass-thru _
-      (start-app nil))))
+      (apply -main *args*))))
 
 (deftask run
   "Starts the server and causes it to wait."

--- a/src/leiningen/new/boot.clj
+++ b/src/leiningen/new/boot.clj
@@ -1,8 +1,7 @@
 (ns leiningen.new.boot
   (:require [leiningen.new.common :refer :all]))
 
-(def boot-dependencies '[[adzerk/boot-test "1.2.0" :scope "test"]
-                         #_[luminus/boot-cprop "1.0.0" :scope "test"]])
+(def boot-dependencies '[[adzerk/boot-test "1.2.0" :scope "test"]])
 
 (defn boot-features [[assets options :as state]]
   (if (some #{"+boot"} (:features options))

--- a/src/leiningen/new/db.clj
+++ b/src/leiningen/new/db.clj
@@ -76,10 +76,16 @@
 
 (defn add-relational-db [db [assets options]]
   [(into assets (relational-db-files options))
-   (let [embedded-db? (some #{(name db)} ["h2" "sqlite"])]
+   (let [embedded-db? (some #{(name db)} ["h2" "sqlite"])
+         boot? (some #{"+boot"} (:features options))]
      (-> options
          (append-options :dependencies (db-dependencies options))
-         (append-options :plugins [['migratus-lein "0.5.4"]])
+         (append-options (if boot?
+                           :dependencies
+                           :plugins)
+                         (if boot?
+                           [['luminus/boot-migratus "1.0.1" :scope "test"]]
+                           [['migratus-lein "0.5.4"]]))
          (assoc
            :relational-db true
            :db-connection (not embedded-db?)


### PR DESCRIPTION
Migratus commands can be run as with lein with something like `boot dev [ run migrate ]`.

The brackets are unfortunately necessary because of how boot does positional parameters. For now, I'm going to leave it like that. The new system with `dev-config.edn` and `test-config.edn` are now fully supported as well.