### PR TITLE
use correct key from env in `reset-db`

### DIFF
--- a/resources/leiningen/new/luminus/core/env/dev/clj/user.clj
+++ b/resources/leiningen/new/luminus/core/env/dev/clj/user.clj
@@ -16,7 +16,7 @@
   (start))
 <% if relational-db %>
 (defn reset-db []
-  (migrations/migrate ["reset"] {:database-url (:config-database-url env)}))
+  (migrations/migrate ["reset"] (select-keys env [:database-url])))
 
 (defn migrate []
   (migrations/migrate ["migrate"] (select-keys env [:database-url])))


### PR DESCRIPTION
In `reset-db` function was used wrong key from `env`.