### PR TITLE
Fix ClojureScript compilation error due to transit-java version.

### DIFF
--- a/src/leiningen/new/cljs.clj
+++ b/src/leiningen/new/cljs.clj
@@ -20,7 +20,8 @@
 (def doo-version "0.1.10")
 
 (def cljs-dependencies
-  [['org.clojure/clojurescript cljs-version :scope "provided"]])
+  [['org.clojure/clojurescript cljs-version :scope "provided"]
+   ['com.cognitect/transit-java "0.8.332"]])
 
 ;;NOTE: under boot, src/cljs is also added to source-paths (see boot-cljs-features)
 


### PR DESCRIPTION
ClojureScript 1.10.339 depends on transit-clj version 0.8.309 and
transit-java 0.8.332. Some imported libraries (cljs-ajax, metosin/muuntaja)
depend on lower versions which override this resulting in ClojureScript
compilation errors.