### PR TITLE
Incorrect namespace for nrepl.server

### DIFF
--- a/resources/leiningen/new/luminus/core/src/nrepl.clj
+++ b/resources/leiningen/new/luminus/core/src/nrepl.clj
@@ -1,5 +1,5 @@
 (ns <<project-ns>>.nrepl
-  (:require [clojure.tools.nrepl.server :as nrepl]
+  (:require [nrepl.server :as nrepl]
             [clojure.tools.logging :as log]))
 
 (defn start


### PR DESCRIPTION
Error on `lein uberjar`
```
java.io.FileNotFoundException: Could not locate clojure/tools/nrepl/server__init.class or clojure/tools/nrepl/server.clj on classpath., compiling:(nrepl.clj:1:1)
Exception in thread "main" java.io.FileNotFoundException: Could not locate clojure/tools/nrepl/server__init.class or clojure/tools/nrepl/server.clj on classpath., compiling:(nrepl.clj:1:1)
```
Version `2.9.12.79` was switched to use nREPL 0.4.4.
Due to [nrepl documentation](https://github.com/nrepl/nREPL#status)
```
[nrepl "0.4.0"] changes the namespaces from clojure.tools.nrepl.* to nrepl.*.
```