### PR TITLE
Update `Dockerfile` template

### DIFF
--- a/resources/leiningen/new/luminus/core/Dockerfile
+++ b/resources/leiningen/new/luminus/core/Dockerfile
@@ -1,7 +1,6 @@
 FROM java:8-alpine
-MAINTAINER Your Name <you@example.com>
 
-ADD target/uberjar/<<name>>.jar /<<name>>/app.jar
+COPY target/uberjar/<<name>>.jar /<<name>>/app.jar
 
 EXPOSE 3000
 


### PR DESCRIPTION
 - `MAINTAINER` is deprecated
 - Use `COPY` instead of `ADD`

Links:
 - https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
 - https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy