### PR TITLE
Adding missing dependency on org.clojure/data.json

### DIFF
--- a/src/leiningen/new/graphql.clj
+++ b/src/leiningen/new/graphql.clj
@@ -7,7 +7,8 @@
    ["{{resource-path}}/graphql/schema.edn" "graphql/resources/schema.edn"]])
 
 (def graphql-dependencies
-  [['com.walmartlabs/lacinia "0.28.0"]])
+  [['com.walmartlabs/lacinia "0.28.0"]
+   ['org.clojure/data.json "0.2.6"]])
 
 (defn graphql-features [[assets options :as state]]
   (if (some #{"+graphql"} (:features options))


### PR DESCRIPTION
I ran lein new luminus myapp +graphql and the resulting project generated did not have a dependency on clojure/data.json in the project.clj file. I added this to the graphql template file.


I wasn't able to test this due to the complexity of getting a local jar build of the lein-template to be used on my system instead of the one installed from maven.