### PR TITLE
not importing from joda.time

### DIFF
--- a/resources/leiningen/new/luminus/core/src/middleware.clj
+++ b/resources/leiningen/new/luminus/core/src/middleware.clj
@@ -17,7 +17,7 @@
             <<auth-session>><% endif %><% if auth-jwe %>
             <<auth-jwe>><% endif %><% endif %>)<% if not service %>
   (:import <% if servlet %>[javax.servlet ServletContext]<% endif %>
-           [org.joda.time ReadableInstant])<% endif %>)
+           )<% endif %>)
 <% if not service %><% if servlet %>
 (defn wrap-context [handler]
   (fn [request]


### PR DESCRIPTION
not sure about this one.... what i was thinking is that the entire joda lib is not being used any more, right?... so therefore there should be no import on it.... also it seams to me, that this import is not being used, which would be good, since joda is not listed in the project deps anymore,.... so i guess really this should result in a some sort of compiler warning? ( my setup does not actually do that )..... in aaany case,... i thought it would be alright to remove this part without actually breaking something..... 

also note that now it seams that the import clause might end up empty altogether.... so i thought maybe i should move the if structures of the template around a bit... but that got me confused also.... :)

so anyways.... do with this pr what you see fit... cheers :)