### PR TITLE
Use `openjdk` docker image instead of `java`

### DIFF
--- a/resources/leiningen/new/luminus/core/Dockerfile
+++ b/resources/leiningen/new/luminus/core/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-alpine
+FROM openjdk:8-alpine
 
 COPY target/uberjar/<<name>>.jar /<<name>>/app.jar
 


### PR DESCRIPTION
Since `java` images are deprecated (see https://hub.docker.com/_/java/)