### PR TITLE
Service tests only for reitit, not swagger (which uses c-api by default)

### DIFF
--- a/resources/leiningen/new/luminus/core/test/handler.clj
+++ b/resources/leiningen/new/luminus/core/test/handler.clj
@@ -23,7 +23,7 @@
 
   (testing "not-found route"
     (let [response (app (request :get "/invalid"))]
-      (is (= 404 (:status response)))))<% if swagger %>
+      (is (= 404 (:status response)))))<% if reitit %>
 
   (testing "services"
 


### PR DESCRIPTION
`+swagger` seems to default to compojure-api, and the new tests are for reitit only. 

(used the template with `+swagger +kee-frame` which adds reitit behind the scenes).