### PR TITLE
[Fix]: Remove Unneeded call to cider/wrap-cljs-repl

### DIFF
--- a/src/leiningen/new/cljs.clj
+++ b/src/leiningen/new/cljs.clj
@@ -102,7 +102,7 @@
    :server-logfile "log/figwheel-logfile.log"
    :nrepl-port       7002
    :css-dirs         ["resources/public/css"]
-   :nrepl-middleware `[cider/wrap-cljs-repl cider.piggieback/wrap-cljs-repl]} )
+   :nrepl-middleware `[cider.piggieback/wrap-cljs-repl]} )
 
 (def cljs-lein-dev-dependencies
   [['figwheel-sidecar figwheel-version]])


### PR DESCRIPTION
**Problem:**

On a freshly generated Leiningen template which included cljs, I noticed starting Figwheel and the corresponding cljs repl caused the following output:

```
Figwheel: Starting server at http://0.0.0.0:3449
Figwheel: Watching build - app
Compiling build :app to "target/cljsbuild/public/js/app.js" from ["src/cljs" "src/cljc" "env/dev/cljs"]...
Successfully compiled build :app to "target/cljsbuild/public/js/app.js" in 1.062 seconds.
Figwheel: Starting CSS Watcher for paths  ["resources/public/css"]
Figwheel: Starting nREPL server on port: 7002
WARNING: unable to load "cider/wrap-cljs-repl" middleware
...
```

**Solution**
- After some digging, it doesn't seem like `cider/wrap-cljs-repl` is a valid namespace or function, and looks superfluous alongside `cider.piggieback/wrap-cljs-repl`.
- While the above warning wasn't causing any noticeable issues with the repl instance, the warning looks unwanted 😄 