### PR TITLE
Added scan attribute to env/dev/resources/logback.xml

### DIFF
--- a/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration>
+<configuration scan="true" scanPeriod="10 seconds">
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are assigned the type


### PR DESCRIPTION
Set the scan attribute to "true" with a scanPeriod of 10 seconds so
logging parameters can be dinamically altered during development.