### PR TITLE
Improve +datomic option

### DIFF
--- a/resources/leiningen/new/luminus/db/src/datomic.clj
+++ b/resources/leiningen/new/luminus/db/src/datomic.clj
@@ -4,7 +4,7 @@
             [<<project-ns>>.config :refer [env]]))
 
 (defstate conn
-  :start (-> env :database-url d/connect)
+  :start (do (-> env :database-url d/create-database) (-> env :database-url d/connect))
   :stop (-> conn .release))
 
 (defn create-schema []
@@ -23,26 +23,56 @@
                 {:db/ident              :user/email
                  :db/valueType          :db.type/string
                  :db/cardinality        :db.cardinality/one
+                 :db/unique             :db.unique/identity
                  :db.install/_attribute :db.part/db}]]
     @(d/transact conn schema)))
 
-(defn entity [conn id]
-  (d/entity (d/db conn) id))
+(defn show-schema
+  "Show currenly installed schema"
+  [conn]
+  (let [system-ns #{"db" "db.type" "db.install" "db.part"
+                    "db.lang" "fressian" "db.unique" "db.excise"
+                    "db.cardinality" "db.fn" "db.sys" "db.bootstrap"
+                    "db.alter"}]
+    (d/q '[:find ?ident
+           :in $ ?system-ns
+           :where
+           [?e :db/ident ?ident]
+           [(namespace ?ident) ?ns]
+           [((comp not contains?) ?system-ns ?ns)]]
+         (d/db conn) system-ns)))
 
-(defn touch [conn results]
-  "takes 'entity ids' results from a query
-    e.g. '#{[272678883689461] [272678883689462] [272678883689459] [272678883689457]}'"
-  (let [e (partial entity conn)]
-    (map #(-> % first e d/touch) results)))
+(defn show-transaction
+  "Show all the transaction data
+   e.g.
+    (-> conn show-transaction count)
+    => the number of transaction"
+  [conn]
+  (seq (d/tx-range (d/log conn) nil nil)))
 
 (defn add-user [conn {:keys [id first-name last-name email]}]
-  @(d/transact conn [{:db/id           id
+  @(d/transact conn [{:user/id         id
                       :user/first-name first-name
                       :user/last-name  last-name
                       :user/email      email}]))
 
-(defn find-user [conn id]
-  (let [user (d/q '[:find ?e :in $ ?id
-                      :where [?e :user/id ?id]]
-                    (d/db conn) id)]
-    (touch conn user)))
+(defn find-one-by
+  "Given db value and an (attr/val), return the user as EntityMap (datomic.query.EntityMap)
+   If there is no result, return nil.
+
+   e.g.
+    (d/touch (find-one-by (d/db conn) :user/email \"user@example.com\"))
+    => show all fields
+    (:user/first-name (find-one-by (d/db conn) :user/email \"user@example.com\"))
+    => show first-name field"
+  [db attr val]
+  (d/entity db
+            ;;find Specifications using ':find ?a .' will return single scalar
+            (d/q '[:find ?e .
+                   :in $ ?attr ?val
+                   :where [?e ?attr ?val]]
+                 db attr val)))
+
+
+(defn find-user [db id]
+  (d/touch (find-one-by db :user/id id)))


### PR DESCRIPTION
1. As mentioned at https://github.com/luminus-framework/luminus-template/issues/415
Given that in datomic, `create-database` is idempotent operation, change to
`:start (do (-> env :database-url d/create-database)(-> env :database-url d/connect))`

2. Fix original `add-user` function

3. Change schema to show how to use `db.unique/identity`

4. Remove original utility function `entity`
   Remove original utility funciton `touch`
   Remote original interface function `find-user`
   I opinionately consider the original example functions are not very
   idiomatic style to use Datomic.

5. Add my version interface function `find-user`
   The first argument is database instead of connection.

6. Add function `show-transaction` to demonstrate how to use `datomic.api/tx-range`
   and `datomic.api/log`

7. Add function `show-schema`