### PR TITLE
Add datomic db migration library 'conformity

### DIFF
--- a/resources/leiningen/new/luminus/db/migrations/schema.edn
+++ b/resources/leiningen/new/luminus/db/migrations/schema.edn
@@ -1,0 +1,45 @@
+{;; norm1 installs the user table schema into Datomic
+ :project-name/norm1 {:txes [[
+   {:db/doc                "User ID"
+    :db/ident              :user/id
+    :db/valueType          :db.type/string
+    :db/cardinality        :db.cardinality/one
+    :db/id                 #db/id [:db.part/db]
+    :db.install/_attribute :db.part/db}
+   {:db/doc                "User screen name"
+    :db/ident              :user/name
+    :db/valueType          :db.type/string
+    :db/cardinality        :db.cardinality/one
+    :db/id                 #db/id [:db.part/db]
+    :db.install/_attribute :db.part/db}
+   {:db/doc                "User email address"
+    :db/ident              :user/email
+    :db/valueType          :db.type/string
+    :db/cardinality        :db.cardinality/one
+    :db/unique             :db.unique/identity
+    :db/id                 #db/id [:db.part/db]
+    :db.install/_attribute :db.part/db}
+   {:db/doc                "User status"
+    :db/ident              :user/status
+    :db/valueType          :db.type/ref
+    :db/cardinality        :db.cardinality/one
+    :db/id                 #db/id [:db.part/db]
+    :db.install/_attribute :db.part/db}
+   ;; example of enumeration in Datomic
+   [:db/add #db/id [:db.part/user] :db/ident :user.status/pending]
+   [:db/add #db/id [:db.part/user] :db/ident :user.status/active]
+   [:db/add #db/id [:db.part/user] :db/ident :user.status/inactive]
+   [:db/add #db/id [:db.part/user] :db/ident :user.status/cancelled]]]}
+
+ ;; norm2 installs certain user init data into Datomic for testing purpose
+ :project-name/norm2 {:txes [[
+   {:user/id     "abc"
+    :user/name   "Good Name A"
+    :user/email  "abc@example.com"
+    :user/status :user.status/active}
+
+   {:user/id     "efg"
+    :user/name   "Good Name B"
+    :user/email  "efg@example.com"
+    :user/status :user.status/active}]]}
+}

--- a/src/leiningen/new/db.clj
+++ b/src/leiningen/new/db.clj
@@ -54,7 +54,8 @@
   [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/mongodb.clj"]])
 
 (def datomic-files
-  [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/datomic.clj"]])
+  [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/datomic.clj"]
+   ["{{resource-path}}/migrations/schema.edn" "db/migrations/schema.edn"]])
 
 (defn add-mongo [[assets options]]
   [(into assets mongo-files)
@@ -82,7 +83,8 @@
                                          :exclusions ['org.slf4j/log4j-over-slf4j
                                                       'org.slf4j/slf4j-nop
                                                       'com.google.guava/guava]]
-                                        ['com.google.guava/guava "25.1-jre"]])))])
+                                        ['com.google.guava/guava "25.1-jre"]
+                                        ['io.rkn/conformity "0.5.1"]])))])
 
 (defn add-relational-db [db [assets options]]
   [(into assets (relational-db-files options))


### PR DESCRIPTION
1. Add datomic migration library `conformity`
2. Change original datomic example to be a more realistic schema.  (Now, this schema has database enumeration.)