### PR TITLE
in +datomic option, let db.core/install-schema to re-read resource

### DIFF
--- a/resources/leiningen/new/luminus/db/src/datomic.clj
+++ b/resources/leiningen/new/luminus/db/src/datomic.clj
@@ -8,15 +8,14 @@
   :start (do (-> env :database-url d/create-database) (-> env :database-url d/connect))
   :stop (-> conn .release))
 
-(def norms-map (c/read-resource "migrations/schema.edn"))
-
 (defn install-schema
   "This function expected to be called at system start up.
 
   Datomic schema migraitons or db preinstalled data can be put into 'migrations/schema.edn'
   Every txes will be executed exactly once no matter how many times system restart."
   [conn]
-  (c/ensure-conforms conn norms-map (keys norms-map)))
+  (let [norms-map (c/read-resource "migrations/schema.edn")]
+    (c/ensure-conforms conn norms-map (keys norms-map))))
 
 (defn show-schema
   "Show currenly installed schema"


### PR DESCRIPTION
In rational development situation, I believe that developer will change `migrations/schema.edn` again and again. Everytime the developer changes the `migrations/schema.edn`, he will re-run the function `(install-schema conn)` and will expect that the new added schema is loaded and installed. 

In original design, the developer needs to first evaluate `norms-map` and then evaluate `(install-schema conn)`, which is not a succinct development flow. 