### PR TITLE
fix a bug in which having no env.clj file would crash the system

### DIFF
--- a/resources/leiningen/new/luminus/core/src/handler.clj
+++ b/resources/leiningen/new/luminus/core/src/handler.clj
@@ -15,8 +15,8 @@
     [<<project-ns>>.config :refer [env]]<% endif %>))
 
 (mount/defstate init-app
-  :start ((or (:init defaults) identity))
-  :stop  ((or (:stop defaults) identity)))
+  :start ((or (:init defaults) (fn [])))
+  :stop  ((or (:stop defaults) (fn []))))
 <% if war %>
 (defn init
   "init will be called once when


### PR DESCRIPTION
refs: https://github.com/luminus-framework/luminus-template/issues/427