### PR TITLE
log stack-traces for all exceptions

### DIFF
--- a/resources/leiningen/new/luminus/core/src/exception.clj
+++ b/resources/leiningen/new/luminus/core/src/exception.clj
@@ -1,0 +1,12 @@
+(ns <<project-ns>>.middleware.exception
+  (:require [reitit.ring.middleware.exception :as exception]
+            [clojure.tools.logging :as log]))
+
+(def exception-middleware
+  (exception/create-exception-middleware
+   (merge
+    exception/default-handlers
+    {;; log stack-traces for all exceptions
+     ::exception/wrap (fn [handler e request]
+                        (log/error e (.getMessage e))
+                        (handler e request))})))

--- a/resources/leiningen/new/luminus/reitit/src/services.clj
+++ b/resources/leiningen/new/luminus/reitit/src/services.clj
@@ -5,11 +5,11 @@
     [reitit.ring.coercion :as coercion]
     [reitit.coercion.spec :as spec-coercion]
     [reitit.ring.middleware.muuntaja :as muuntaja]
-    [reitit.ring.middleware.exception :as exception]
     [reitit.ring.middleware.multipart :as multipart]
     [reitit.ring.middleware.parameters :as parameters]<% if graphql %>
     [<<project-ns>>.routes.services.graphql :as graphql]<% endif %>
     [<<project-ns>>.middleware.formats :as formats]
+    [<<project-ns>>.middleware.exception :as exception]
     [ring.util.http-response :refer :all]
     [clojure.java.io :as io]))
 

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -64,6 +64,7 @@
    ["{{backend-path}}/{{sanitized}}/layout.clj" "core/src/layout.clj"]
    ["{{backend-path}}/{{sanitized}}/middleware.clj" "core/src/middleware.clj"]
    ["{{backend-path}}/{{sanitized}}/middleware/formats.clj" "core/src/formats.clj"]
+   ["{{backend-path}}/{{sanitized}}/middleware/exception.clj" "core/src/exception.clj"]
 
    ;;HTML templates
    ["{{resource-path}}/html/base.html" "core/resources/html/base.html"]


### PR DESCRIPTION
all exceptions in api  intercepted by original exception-middleware, when an exception occurs, the developer can not know what happened, so i wrap the exception-middleware to log the exception.
#429 