### PR TITLE
update reitit to 0.3.5

### DIFF
--- a/src/leiningen/new/reitit.clj
+++ b/src/leiningen/new/reitit.clj
@@ -9,6 +9,6 @@
   (if (some #{"+reitit"} (:features options))
     [(into (remove-conflicting-assets assets "home.clj" "docs.md") reitit-assets)
      (-> options
-         (append-options :dependencies [['metosin/reitit "0.3.1"]])
+         (append-options :dependencies [['metosin/reitit "0.3.5"]])
          (assoc :reitit true))]
     state))


### PR DESCRIPTION
Fixes a really bad bug with [bleeding path parameters](https://github.com/metosin/reitit/blob/master/CHANGELOG.md#035-2019-05-22).