### PR TITLE
fix navigation, use class attr instead of active

### DIFF
--- a/resources/leiningen/new/luminus/keeframe/src/cljs/view.cljs
+++ b/resources/leiningen/new/luminus/keeframe/src/cljs/view.cljs
@@ -8,7 +8,7 @@
 (defn nav-link [title page]
   [:a.navbar-item
    {:href   (kf/path-for [page])
-    :active (when (= page @(rf/subscribe [:nav/page])) "is-active")}
+    :class (when (= page @(rf/subscribe [:nav/page])) "is-active")}
    title])
 
 (defn navbar []

--- a/resources/leiningen/new/luminus/reagent/src/cljs/core.cljs
+++ b/resources/leiningen/new/luminus/reagent/src/cljs/core.cljs
@@ -16,7 +16,7 @@
 (defn nav-link [uri title page]
   [:a.navbar-item
    {:href   uri
-    :active (when (= page (:page @session)) "is-active")}
+    :class (when (= page (:page @session)) "is-active")}
    title])
 
 (defn navbar []


### PR DESCRIPTION
Hi,

  the navigation does not show the currently active page correctly, this seems to fix it.

T