### PR TITLE
Human-optimized messages from clojure.spec validation errors

### DIFF
--- a/resources/leiningen/new/luminus/reitit/src/exception.clj
+++ b/resources/leiningen/new/luminus/reitit/src/exception.clj
@@ -19,6 +19,6 @@
      ::exception/wrap (fn [handler e request]
                         (log/error e (.getMessage e))
                         (handler e request))
-     ;; human-optimized validation message
+     ;; human-optimized validation messages
      ::coercion/request-coercion (coercion-error-handler 400)
      ::coercion/response-coercion (coercion-error-handler 500)})))

--- a/resources/leiningen/new/luminus/reitit/src/exception.clj
+++ b/resources/leiningen/new/luminus/reitit/src/exception.clj
@@ -1,6 +1,15 @@
 (ns <<project-ns>>.middleware.exception
-  (:require [reitit.ring.middleware.exception :as exception]
-            [clojure.tools.logging :as log]))
+  (:require [clojure.tools.logging :as log]
+            [expound.alpha :as expound]
+            [reitit.coercion :as coercion]
+            [reitit.ring.middleware.exception :as exception]))
+
+(defn coercion-error-handler [status]
+  (let [printer (expound/custom-printer {:print-specs? false})]
+    (fn [exception request]
+      {:status status
+       :headers {"Content-Type" "text/html"}
+       :body (with-out-str (printer (-> exception ex-data :problems)))})))
 
 (def exception-middleware
   (exception/create-exception-middleware
@@ -9,4 +18,6 @@
     {;; log stack-traces for all exceptions
      ::exception/wrap (fn [handler e request]
                         (log/error e (.getMessage e))
-                        (handler e request))})))
+                        (handler e request))
+     ;; human-optimized validation message
+     ::coercion/request-coercion (coercion-error-handler 400)})))

--- a/resources/leiningen/new/luminus/reitit/src/exception.clj
+++ b/resources/leiningen/new/luminus/reitit/src/exception.clj
@@ -20,4 +20,5 @@
                         (log/error e (.getMessage e))
                         (handler e request))
      ;; human-optimized validation message
-     ::coercion/request-coercion (coercion-error-handler 400)})))
+     ::coercion/request-coercion (coercion-error-handler 400)
+     ::coercion/response-coercion (coercion-error-handler 500)})))

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -138,11 +138,11 @@
    ['mount "0.1.16"]
    ['cprop "0.1.14"]
    ['org.clojure/tools.cli "0.4.2"]
-   ['nrepl "0.6.0"]])
+   ['nrepl "0.6.0"]
+   ['expound "0.7.2"]])
 
 (def core-dev-dependencies
-  [['expound "0.7.2"]
-   ['prone "2019-07-08"]
+  [['prone "2019-07-08"]
    ['ring/ring-mock "0.4.0"]
    ['ring/ring-devel "1.7.1"]
    ['pjstadig/humane-test-output "0.9.0"]])


### PR DESCRIPTION
Hi Dmitri,

As discussed in Slack. Let me know if this is satisfactory.

Results in validation messages like this:

![expound validation message](https://i.imgur.com/5Cic7wb.png)

Kind regards,
Erwin