### PR TITLE
Fix Linter warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.asc
 .*
 /target/
 *.iml
+tmp

--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,6 @@
   :eval-in-leiningen true
   :dependencies [[leinjacker "0.4.2"]
                  [selmer "1.11.7"]]
-  :plugins [[lein-cljfmt "0.6.4"]])
+  :plugins [[lein-cljfmt "0.6.4"]
+            [commons-io/commons-io "2.6"]])
+

--- a/resources/leiningen/new/luminus/core/env/dev/clj/user.clj
+++ b/resources/leiningen/new/luminus/core/env/dev/clj/user.clj
@@ -1,7 +1,8 @@
 (ns user
   "Userspace functions you can run by default in your local REPL."
   (:require
-    [<<project-ns>>.config :refer [env]]
+   [<<project-ns>>.config :refer [env]]
+    [clojure.pprint]
     [clojure.spec.alpha :as s]
     [expound.alpha :as expound]
     [mount.core :as mount]<% if figwheel %>

--- a/resources/leiningen/new/luminus/core/env/dev/clj/user.clj
+++ b/resources/leiningen/new/luminus/core/env/dev/clj/user.clj
@@ -15,24 +15,24 @@
 
 (add-tap (bound-fn* clojure.pprint/pprint))
 
-(defn start 
+(defn start
   "Starts application.
   You'll usually want to run this on startup."
   []
   (mount/start-without #'<<project-ns>>.core/repl-server))
 
-(defn stop 
+(defn stop
   "Stops application."
   []
   (mount/stop-except #'<<project-ns>>.core/repl-server))
 
-(defn restart 
+(defn restart
   "Restarts application."
   []
   (stop)
   (start))
 <% if relational-db %>
-(defn restart-db 
+(defn restart-db
   "Restarts database."
   []
   (mount/stop #'<<project-ns>>.db.core/*db*)
@@ -40,22 +40,22 @@
   (binding [*ns* '<<project-ns>>.db.core]
     (conman/bind-connection <<project-ns>>.db.core/*db* "sql/queries.sql")))
 
-(defn reset-db 
+(defn reset-db
   "Resets database."
   []
   (migrations/migrate ["reset"] (select-keys env [:database-url])))
 
-(defn migrate 
+(defn migrate
   "Migrates database up for all outstanding migrations."
   []
   (migrations/migrate ["migrate"] (select-keys env [:database-url])))
 
-(defn rollback 
+(defn rollback
   "Rollback latest database migration."
   []
   (migrations/migrate ["rollback"] (select-keys env [:database-url])))
 
-(defn create-migration 
+(defn create-migration
   "Create a new up and down migration file with a generated timestamp and `name`."
   [name]
   (migrations/create name (select-keys env [:database-url])))

--- a/resources/leiningen/new/luminus/core/project.clj
+++ b/resources/leiningen/new/luminus/core/project.clj
@@ -14,6 +14,9 @@
   :main ^:skip-aot <<project-ns>>.core
 
   :plugins [<% if plugins %><<plugins>><% endif %>]<% if cucumber-feature-paths %>
+  ;; Exclude :no-ns-form-found linter to avoid warnings on step definitions.
+  ;; This can be done per step file once https://github.com/jonase/eastwood/issues/165 is done.
+  :eastwood {:exclude-linters [:no-ns-form-found]}
   :cucumber-feature-paths <<cucumber-feature-paths>><% endif %><% if sassc-config-params %>
   <<sassc-config-params>>
   <<sassc-auto-config>>

--- a/resources/leiningen/new/luminus/core/src/layout.clj
+++ b/resources/leiningen/new/luminus/core/src/layout.clj
@@ -1,11 +1,13 @@
 (ns <<project-ns>>.layout
   (:require
+    [clojure.java.io]
     [selmer.parser :as parser]
     [selmer.filters :as filters]
     [markdown.core :refer [md-to-html-string]]
     [ring.util.http-response :refer [content-type ok]]
     [ring.util.anti-forgery :refer [anti-forgery-field]]
-    [ring.middleware.anti-forgery :refer [*anti-forgery-token*]]))
+    [ring.middleware.anti-forgery :refer [*anti-forgery-token*]]
+    [ring.util.response]))
 
 (parser/set-resource-path!  (clojure.java.io/resource "html"))
 (parser/add-tag! :csrf-field (fn [_ _] (anti-forgery-field)))

--- a/resources/leiningen/new/luminus/core/src/middleware.clj
+++ b/resources/leiningen/new/luminus/core/src/middleware.clj
@@ -17,8 +17,8 @@
     <<auth-middleware-required>><% if auth-session %>
     <<auth-session>><% endif %><% if auth-jwe %>
     <<auth-jwe>><% endif %><% endif %>)<% if not service %>
-  (:import <% if servlet %>[javax.servlet ServletContext]<% endif %>
-           )<% endif %>)
+  <% if servlet %>(:import [javax.servlet ServletContext])<% endif %>
+           <% endif %>)
 <% if not service %><% if servlet %>
 (defn wrap-context [handler]
   (fn [request]

--- a/resources/leiningen/new/luminus/db/src/sql.db.clj
+++ b/resources/leiningen/new/luminus/db/src/sql.db.clj
@@ -11,6 +11,7 @@
     [clojure.tools.logging :as log]
     [conman.core :as conman]
     [java-time :as jt]
+    [java-time.pre-java8]
     [<<project-ns>>.config :refer [env]]
     [mount.core :refer [defstate]])
   (:import org.postgresql.util.PGobject
@@ -25,7 +26,7 @@
     [clojure.java.jdbc :as jdbc]
     [clojure.tools.logging :as log]
     [conman.core :as conman]
-    [java-time.pre-java8 :as jt]
+    [java-time.pre-java8]
     [<<project-ns>>.config :refer [env]]
     [mount.core :refer [defstate]])
   (:import [java.sql

--- a/resources/leiningen/new/luminus/db/src/sql.db.clj
+++ b/resources/leiningen/new/luminus/db/src/sql.db.clj
@@ -26,7 +26,7 @@
     [clojure.java.jdbc :as jdbc]
     [clojure.tools.logging :as log]
     [conman.core :as conman]
-    [java-time.pre-java8]
+    [java-time.pre-java8 :as jt]
     [<<project-ns>>.config :refer [env]]
     [mount.core :refer [defstate]])
   (:import [java.sql

--- a/resources/leiningen/new/luminus/db/test/db/core.clj
+++ b/resources/leiningen/new/luminus/db/test/db/core.clj
@@ -1,6 +1,8 @@
 (ns <<project-ns>>.test.db.core
   (:require
-    [<<project-ns>>.db.core :refer [*db*] :as db]
+   [<<project-ns>>.db.core :refer [*db*] :as db]
+   [java-time.pre-java8]
+   [
     [luminus-migrations.core :as migrations]
     [clojure.test :refer :all]
     [clojure.java.jdbc :as jdbc]

--- a/resources/leiningen/new/luminus/db/test/db/core.clj
+++ b/resources/leiningen/new/luminus/db/test/db/core.clj
@@ -2,19 +2,18 @@
   (:require
    [<<project-ns>>.db.core :refer [*db*] :as db]
    [java-time.pre-java8]
-   [
-    [luminus-migrations.core :as migrations]
-    [clojure.test :refer :all]
-    [clojure.java.jdbc :as jdbc]
-    [<<project-ns>>.config :refer [env]]
-    [mount.core :as mount]))
+   [luminus-migrations.core :as migrations]
+   [clojure.test :refer :all]
+   [clojure.java.jdbc :as jdbc]
+   [<<project-ns>>.config :refer [env]]
+   [mount.core :as mount]))
 
 (use-fixtures
   :once
   (fn [f]
     (mount/start
-      #'<<project-ns>>.config/env
-      #'<<project-ns>>.db.core/*db*)
+     #'<<project-ns>>.config/env
+     #'<<project-ns>>.db.core/*db*)
     (migrations/migrate ["migrate"] (select-keys env [:database-url]))
     (f)))
 
@@ -22,12 +21,12 @@
   (jdbc/with-db-transaction [t-conn *db*]
     (jdbc/db-set-rollback-only! t-conn)
     (is (= 1 (db/create-user!
-               t-conn
-               {:id         "1"
-                :first_name "Sam"
-                :last_name  "Smith"
-                :email      "sam.smith@example.com"
-                :pass       "pass"})))
+              t-conn
+              {:id         "1"
+               :first_name "Sam"
+               :last_name  "Smith"
+               :email      "sam.smith@example.com"
+               :pass       "pass"})))
     (is (= {:id         "1"
             :first_name "Sam"
             :last_name  "Smith"

--- a/resources/leiningen/new/luminus/reitit/src/home.clj
+++ b/resources/leiningen/new/luminus/reitit/src/home.clj
@@ -1,11 +1,11 @@
 (ns <<project-ns>>.routes.home
   (:require
-    [<<project-ns>>.layout :as layout]<% if relational-db %>
-    [<<project-ns>>.db.core :as db]<% endif %>
-    [clojure.java.io :as io]
-    [<<project-ns>>.middleware :as middleware]
-    [ring.util.response]
-    [ring.util.http-response :as response]))
+   [<<project-ns>>.layout :as layout]<% if relational-db %>
+   [<<project-ns>>.db.core :as db]<% endif %>
+   [clojure.java.io :as io]
+   [<<project-ns>>.middleware :as middleware]
+   [ring.util.response]
+   [ring.util.http-response :as response]))
 <% if cljs  %>
 (defn home-page [request]
   (layout/render request "home.html"))

--- a/resources/leiningen/new/luminus/reitit/src/home.clj
+++ b/resources/leiningen/new/luminus/reitit/src/home.clj
@@ -4,6 +4,7 @@
     [<<project-ns>>.db.core :as db]<% endif %>
     [clojure.java.io :as io]
     [<<project-ns>>.middleware :as middleware]
+    [ring.util.response]
     [ring.util.http-response :as response]))
 <% if cljs  %>
 (defn home-page [request]

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -148,7 +148,8 @@
    ['pjstadig/humane-test-output "0.9.0"]])
 
 (def core-dev-plugins
-  [['com.jakemccrary/lein-test-refresh "0.24.1"]])
+  [['com.jakemccrary/lein-test-refresh "0.24.1"]
+   ['jonase/eastwood "0.3.5"]])
 
 (defn generate-project
   "Create a new Luminus project"

--- a/test/test_templates.clj
+++ b/test/test_templates.clj
@@ -38,15 +38,30 @@
   "Smoke-tests each individual template option.
   For each supported template option, generates a template with that option, lints it, and compiles it."
   (doseq [template-option
-          ["+aleph"
+          [;; Doesn't compile: Couldn't find project.clj, which is needed for compile
+           ;; "+boot"
+
+           ;; Doesn't compile: Couldn't find project.clj, which is needed for compile
+           ;; "+diatomic"
+
+           ;; Doesn't parse: {:type :reader-exception, :ex-kind :reader-error}
+           ;; "+h2"
+
+           ;; Doesn't parse: {:type :reader-exception, :ex-kind :reader-error}
+           ;; "+mysql"
+
+           ;; Doesn't parse: {:type :reader-exception, :ex-kind :reader-error}
+           ;; "+postgres"
+
+           ;; Doesn't parse: {:type :reader-exception, :ex-kind :reader-error}
+           ;; "+sqlite"
+
+           "+aleph"
            "+auth"
            "+auth-jwe"
-           "+boot"
            "+cljs"
-           "+cucumber"
-           "+datomic"
+            "+cucumber"
            "+graphql"
-           "+h2"
            "+hoplon"
            "+http-kit"
            "+immutant"
@@ -54,9 +69,7 @@
            "+kee-frame"
            "+kibit"
            "+mongodb"
-           "+mysql"
            "+oauth"
-           "+postgres"
            "+reagent"
            "+re-frame"
            "+reitit"
@@ -65,7 +78,6 @@
            "+servlet"
            "+shadow-cljs"
            "+site"
-           "+sqlite"
            "+swagger"
            "+war"]]
     (with-temp-dir temp-pathname

--- a/test/test_templates.clj
+++ b/test/test_templates.clj
@@ -1,8 +1,74 @@
 (ns test-templates
   (:require [clojure.test :refer :all]
-            [clojure.java.shell :only [sh] :as shell]))
+            [clojure.java.shell :only [sh] :as shell])
+  (:import [java.nio.file Files]
+           [org.apache.commons.io FileUtils]))
 
-(deftest test-noop
-  (print (shell/sh "lein" "new" "luminus" "tmp"))
-  (is (= 1 1)))
+(defmacro with-temp-dir [pathname-var & body]
+  "Creates a temporary directory, then executes body, binding pathname-var as the pathname to the temporary directory.
+  Note that the temporary directory is recursively deleted after body is executed."
+  `(let [temp-dir# (Files/createTempDirectory "luminus-template" (into-array java.nio.file.attribute.FileAttribute []))
+         temp-dir-file# (.toFile temp-dir#)
+         ~pathname-var (.toString temp-dir#)]
+     (try
+       ~@body
+       (finally (FileUtils/deleteDirectory temp-dir-file#)))))
 
+(defmacro with-persistent-temp-dir [pathname-var & body]
+  "Creates a temporary directory, then executes body, binding pathname-var as the pathname to the temporary directory.
+  Note that the temporary directory is not deleted after body is executed."
+  `(let [temp-dir# (Files/createTempDirectory "luminus-template" (into-array java.nio.file.attribute.FileAttribute []))
+         temp-dir-file# (.toFile temp-dir#)
+         ~pathname-var (.toString temp-dir#)]
+     ~@body))
+
+(defn sh-logging-err [& args]
+  "Runs a shell command, returning exit code.
+  If the exit code is 0, succeed silently.  If the exit code is non-zero, write :out to STDOUT, and :err to STDERR."
+  (let [result (apply shell/sh args)
+        exit-code (:exit result)]
+    (if (not (= 0 exit-code))
+      (do
+        (println (:out result))
+        (binding [*out* *err*]
+          (println (:err result)))))
+    exit-code))
+
+(deftest smoke-test-templates
+  "Smoke-tests each individual template option.
+  For each supported template option, generates a template with that option, lints it, and compiles it."
+  (doseq [template-option
+          ["+aleph"
+           "+auth"
+           "+auth-jwe"
+           "+boot"
+           "+cljs"
+           "+cucumber"
+           "+datomic"
+           "+graphql"
+           "+h2"
+           "+hoplon"
+           "+http-kit"
+           "+immutant"
+           "+jetty"
+           "+kee-frame"
+           "+kibit"
+           "+mongodb"
+           "+mysql"
+           "+oauth"
+           "+postgres"
+           "+reagent"
+           "+re-frame"
+           "+reitit"
+           "+sassc"
+           "+service"
+           "+servlet"
+           "+shadow-cljs"
+           "+site"
+           "+sqlite"
+           "+swagger"
+           "+war"]]
+    (with-temp-dir temp-pathname
+      (is (= 0 (sh-logging-err "lein" "new" "luminus" "test-project" ":to-dir" temp-pathname ":force" "t" template-option)) (str "Generate Luminus project with template option " template-option))
+      (is (= 0 (sh-logging-err "lein" "compile" :dir temp-pathname)) (str "Compile Luminus project created with template option " template-option))
+      (is (= 0 (sh-logging-err "lein" "eastwood" :dir temp-pathname)) (str "Lint Luminus project created with template option " template-option)))))

--- a/test/test_templates.clj
+++ b/test/test_templates.clj
@@ -39,30 +39,16 @@
   For each supported template option, generates a template with that option, lints it, and compiles it.
   If you'd like to examine the generated projects, use with-persistent-temp-dir instead of with-temp-dir."
   (doseq [template-option
-          [;; Doesn't compile: Couldn't find project.clj, which is needed for compile
-           ;; "+boot"
-
-           ;; Doesn't compile: Couldn't find project.clj, which is needed for compile
-           ;; "+diatomic"
-
-           ;; Doesn't parse: {:type :reader-exception, :ex-kind :reader-error}
-           ;; "+h2"
-
-           ;; Doesn't parse: {:type :reader-exception, :ex-kind :reader-error}
-           ;; "+mysql"
-
-           ;; Doesn't parse: {:type :reader-exception, :ex-kind :reader-error}
-           ;; "+postgres"
-
-           ;; Doesn't parse: {:type :reader-exception, :ex-kind :reader-error}
-           ;; "+sqlite"
-
+          [
            "+aleph"
            "+auth"
            "+auth-jwe"
+           "+boot"
            "+cljs"
-            "+cucumber"
+           "+cucumber"
+           "+diatomic"
            "+graphql"
+           "+h2"
            "+hoplon"
            "+http-kit"
            "+immutant"
@@ -70,7 +56,9 @@
            "+kee-frame"
            "+kibit"
            "+mongodb"
+           "+mysql"
            "+oauth"
+           "+postgres"
            "+reagent"
            "+re-frame"
            "+reitit"
@@ -79,8 +67,10 @@
            "+servlet"
            "+shadow-cljs"
            "+site"
+           "+sqlite"
            "+swagger"
-           "+war"]]
+           "+war"
+           ]]
     (with-temp-dir temp-pathname
       (is (= 0 (sh-logging-err "lein" "new" "luminus" "test-project" ":to-dir" temp-pathname ":force" "t" template-option)) (str "Generate Luminus project with template option " template-option))
       (is (= 0 (sh-logging-err "lein" "compile" :dir temp-pathname)) (str "Compile Luminus project created with template option " template-option))

--- a/test/test_templates.clj
+++ b/test/test_templates.clj
@@ -1,5 +1,8 @@
 (ns test-templates
-  (:require [clojure.test :refer :all]))
+  (:require [clojure.test :refer :all]
+            [clojure.java.shell :only [sh] :as shell]))
 
 (deftest test-noop
-    (is (= 2 (+ 1 1))))
+  (print (shell/sh "lein" "new" "luminus" "tmp"))
+  (is (= 1 1)))
+

--- a/test/test_templates.clj
+++ b/test/test_templates.clj
@@ -39,14 +39,15 @@
   For each supported template option, generates a template with that option, lints it, and compiles it.
   If you'd like to examine the generated projects, use with-persistent-temp-dir instead of with-temp-dir."
   (doseq [template-option
-          [
+          [;; Don't test +boot, as this smoke-test only works w/ Leiningen right now.
+           ;; "+boot"
+
            "+aleph"
            "+auth"
            "+auth-jwe"
-           "+boot"
            "+cljs"
            "+cucumber"
-           "+diatomic"
+           "+datomic"
            "+graphql"
            "+h2"
            "+hoplon"
@@ -69,8 +70,7 @@
            "+site"
            "+sqlite"
            "+swagger"
-           "+war"
-           ]]
+           "+war"]]
     (with-temp-dir temp-pathname
       (is (= 0 (sh-logging-err "lein" "new" "luminus" "test-project" ":to-dir" temp-pathname ":force" "t" template-option)) (str "Generate Luminus project with template option " template-option))
       (is (= 0 (sh-logging-err "lein" "compile" :dir temp-pathname)) (str "Compile Luminus project created with template option " template-option))

--- a/test/test_templates.clj
+++ b/test/test_templates.clj
@@ -1,0 +1,5 @@
+(ns test-templates
+  (:require [clojure.test :refer :all]))
+
+(deftest test-noop
+    (is (= 2 (+ 1 1))))

--- a/test/test_templates.clj
+++ b/test/test_templates.clj
@@ -36,7 +36,8 @@
 
 (deftest smoke-test-templates
   "Smoke-tests each individual template option.
-  For each supported template option, generates a template with that option, lints it, and compiles it."
+  For each supported template option, generates a template with that option, lints it, and compiles it.
+  If you'd like to examine the generated projects, use with-persistent-temp-dir instead of with-temp-dir."
   (doseq [template-option
           [;; Doesn't compile: Couldn't find project.clj, which is needed for compile
            ;; "+boot"


### PR DESCRIPTION
This introduces a single test that iterates through each of the available Luminus command line flags, creating a project with each flag enabled, then linting it.

Note that it doesn't test the `+boot` flag, as the tests are currently Leiningen-only.

```
          [;; Don't test +boot, as this smoke-test only works w/ Leiningen right now.
           ;; "+boot"
```

It also disables the linter specifically for missing `ns` forms when dealing with Cucumber steps, because there's no way to disable linters [just for the step definitions](https://github.com/jonase/eastwood/issues/165).

Fixes #447.