### PR TITLE
Remove unused code in re-frame profile

### DIFF
--- a/resources/leiningen/new/luminus/reframe/src/cljs/core.cljs
+++ b/resources/leiningen/new/luminus/reframe/src/cljs/core.cljs
@@ -44,10 +44,6 @@
    (when-let [docs @(rf/subscribe [:docs])]
      [:div {:dangerouslySetInnerHTML {:__html (md->html docs)}}])])
 
-(def pages
-  {:home #'home-page
-   :about #'about-page})
-
 (defn page []
   (if-let [page @(rf/subscribe [:page])]
     [:div


### PR DESCRIPTION
This removes some code that is no longer used. At least I think it's not used? It looks like the router now keeps track of the page to fn mapping.