### PR TITLE
Fix shadow-cljs build error caused by dependency conflicts

### DIFF
--- a/src/leiningen/new/shadow_cljs.clj
+++ b/src/leiningen/new/shadow_cljs.clj
@@ -1,12 +1,12 @@
 (ns leiningen.new.shadow-cljs
   (:require [leiningen.new.common :refer :all]))
 
-(def shadow-version "2.8.69")
+(def shadow-version "2.8.92")
 
-(def shadow-cljs-dependencies [['com.google.javascript/closure-compiler-unshaded "v20190618" :scope "provided"]
-                               ['org.clojure/google-closure-library "0.0-20190213-2033d5d9" :scope "provided"]
+(def shadow-cljs-dependencies [['com.google.javascript/closure-compiler-unshaded "v20191027" :scope "provided"]
+                               ['org.clojure/google-closure-library "0.0-20191016-6ae1f72f" :scope "provided"]
                                ['thheller/shadow-cljs shadow-version :scope "provided"]
-                               ['org.clojure/core.async "0.4.500"]])
+                               ['org.clojure/core.async "1.0.567"]])
 
 (def shadow-cljs-plugins [['lein-shadow "0.1.7"]])
 


### PR DESCRIPTION
With the previous explicit dependencies

```clojure
['com.google.javascript/closure-compiler-unshaded "v20190618" :scope "provided"]
['org.clojure/google-closure-library "0.0-20190213-2033d5d9" :scope "provided"]
```

requiring an NPM package via `(:require ["package-name"])` causes shadow-cljs to throw confusing exceptions like:

```
IllegalArgumentException: No matching field found: getSourceName for class com.google.javascript.jscomp.JSError
```

which is seen discussed at https://clojurians-log.clojureverse.org/shadow-cljs/2020-01-06/1578325220.333700.

This PR fixes that by updating the Closure dependencies.

The PR also bumps the versions of shadow-cljs and core.async; if that's unwanted we can undo it.