### PR TITLE
Add Calva configurations

### DIFF
--- a/resources/leiningen/new/luminus/calva/client.code-workspace
+++ b/resources/leiningen/new/luminus/calva/client.code-workspace
@@ -1,0 +1,23 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"calva.replConnectSequences": [
+			{
+				"name": "<<name>> lein-shadow Client",
+				"projectType": "lein-shadow",
+				"cljsType": "shadow-cljs",
+				"menuSelections": {
+					"cljsLaunchBuilds": [
+						"app",
+						"test"
+					],
+					"cljsDefaultBuild": "app"
+				}
+			}
+		]
+	}
+}

--- a/resources/leiningen/new/luminus/calva/custom-commands-fragment.json
+++ b/resources/leiningen/new/luminus/calva/custom-commands-fragment.json
@@ -1,0 +1,20 @@
+    "calva.customREPLCommandSnippets": [
+        {
+            "name": "Start <<name>> Server",
+            "ns": "user",
+            "repl": "clj",
+            "snippet": "(start)"
+        },
+        {
+            "name": "Stop <<name>> Server",
+            "ns": "user",
+            "repl": "clj",
+            "snippet": "(stop)"
+        },
+        {
+            "name": "Restart <<name>> Server",
+            "ns": "user",
+            "repl": "clj",
+            "snippet": "(restart)"
+        }
+    ],

--- a/resources/leiningen/new/luminus/calva/figwheel-settings.json
+++ b/resources/leiningen/new/luminus/calva/figwheel-settings.json
@@ -1,0 +1,24 @@
+{
+    <% include calva/custom-commands-fragment.json %>,
+    "calva.replConnectSequences": [
+        <% include calva/server-connect-sequence-fragment.json %>,
+        {
+            "name": "Server + Client – <<name>>",
+            "projectType": "Leiningen",
+            "afterCLJReplJackInCode": "(start)",
+            "cljsType": {
+                "dependsOn": "lein-figwheel",
+                "connectCode": "(do (println (str \"Starting Fighweel. Client URL is http://0.0.0.0:\" (:port (clojure.edn/read-string (slurp \"dev-config.edn\"))))) (use 'figwheel-sidecar.repl-api) (when-not (figwheel-sidecar.repl-api/figwheel-running?) (figwheel-sidecar.repl-api/start-figwheel!)) (figwheel-sidecar.repl-api/cljs-repl))",
+                "isConnectedRegExp": "To quit, type: :cljs/quit",
+                "openUrlRegExp": "Client URL is (?<url>\\S+)",
+                "shouldOpenUrl": true,
+                "isReadyToStartRegExp": "Prompt will show"
+            },
+            "menuSelections": {
+                "leinProfiles": [
+                    "dev"
+                ]
+            }
+        }
+    ]
+}

--- a/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
+++ b/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
@@ -1,0 +1,11 @@
+        {
+            "name": "Server only - <<name>>",
+            "projectType": "Leiningen",
+            "afterCLJReplJackInCode": "(start)",
+            "cljsType": "none",
+            "menuSelections": {
+                "leinProfiles": [
+                    "dev"
+                ]
+            }
+        }

--- a/resources/leiningen/new/luminus/calva/server-only-settings.json
+++ b/resources/leiningen/new/luminus/calva/server-only-settings.json
@@ -1,0 +1,6 @@
+{
+    <% include calva/custom-commands-fragment.json %>,
+    "calva.replConnectSequences": [
+        <% include calva/server-connect-sequence-fragment.json %>
+    ]
+}

--- a/resources/leiningen/new/luminus/calva/server.code-workspace
+++ b/resources/leiningen/new/luminus/calva/server.code-workspace
@@ -1,0 +1,13 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		<% include calva/custom-commands-fragment.json %>,
+		"calva.replConnectSequences": [
+	        <% include calva/server-connect-sequence-fragment.json %>
+		]
+	}
+}

--- a/src/leiningen/new/calva.clj
+++ b/src/leiningen/new/calva.clj
@@ -1,0 +1,16 @@
+(ns leiningen.new.calva)
+
+(defn calva-files [options]
+  (cond 
+    (some #{"+shadow-cljs"} (:features options))
+    [["{{name}} Server.code-workspace" "calva/server.code-workspace"]
+     ["{{name}} Client.code-workspace" "calva/client.code-workspace"]]
+    
+    (some #{"+cljs"} (:features options))
+    [[".vscode/settings.json" "calva/figwheel-settings.json"]]
+    
+    :else
+    [[".vscode/settings.json" "calva/server-only-settings.json"]]))
+
+(defn calva-features [[assets options]]
+  [(into assets (calva-files options)) options])

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -33,7 +33,8 @@
             [leiningen.new.kibit :refer [kibit-features]]
             [leiningen.new.logback :refer [logback-features]]
             [leiningen.new.service :refer [service-features]]
-            [leiningen.new.oauth :refer [oauth-features]]))
+            [leiningen.new.oauth :refer [oauth-features]]
+            [leiningen.new.calva :refer [calva-features]]))
 
 (defn resource [r]
   (->> r (str "leiningen/new/luminus/core/resources/") (io/resource)))
@@ -155,6 +156,7 @@
   "Create a new Luminus project"
   [options]
   (main/info "Generating a Luminus project.")
+  (main/info (pr-str options))
   (let [[assets options]
         (-> [core-assets options]
             lein-features
@@ -184,7 +186,8 @@
             kibit-features
             logback-features
             oauth-features
-            war-features)]
+            war-features
+            calva-features)]
     (render-assets assets binary-assets (format-options options))))
 
 (defn format-features [features]


### PR DESCRIPTION
This adds Calva settings for easier **start hacking** for these scenarios:

- Server only
- Server + shadow
- Server + figwheel

With these settings the story can be told like so:

# How to use Calva with the Luminus Project Template

[Luminus](https://luminusweb.com) is a powerful and versitle Leiningen template for creating web development projects. It comes with built in configuration for making it easy to use Calva as your Clojure(Script) editor. Here are the steps involved.

## Server Only

The workflow here is really just: Jack-in and start hacking. The first time it involves these steps, however:

0. If you haven't created the project yet, create a new server only Luminus project. For a all-defaults setup it is like so:
    ```sh
    $ lein new luminus my-luminus-server
    ```
0. This creates the folder `my-luminus-server`. Open it in VS Code:
    ```sh
    $ code my-luminus-server
    ```
0. Use the Calva command **Start a Project REPL and Connect (aka Jack-in)**: `ctrl+alt+c ctrl+alt+j` and wait for the **Calva says** output to say `Jack-in done.`
0. Open http://0.0.0.0:3000 in your web browser and start hacking.


## Server and shadow-cljs

For shadow-cljs Luminus projects, the workflow is: Jack-in to the server, then Jack-in to the client, then start hacking. The first time it involves these steps:

0. If you haven't created the project yet, create a new shadow-cljs Luminus project. E.g.:
    ```sh
    $ lein new luminus my-luminus-shadow
    ```

This creates the folder `my-luminus-shadow`, which will contain two VS Code Workspaces – one for the server, and one for the client.


### Server Workspace

1. Open the project folder:
   ```sh
   $ code my-luminus-shadow
   ```
1. VS Code should offer you a button to select a workspace, click it and select **Server-my-luminus-shadow**. (Otherwise do **File -> Open Workspace...**)
1. Use the Calva command **Start a Project REPL and Connect (aka Jack-in)**: `ctrl+alt+c ctrl+alt+j` and wait for the **Calva says** _Output channel_ to say `Jack-in done.`
1. Continue to the Client

### Client Workspace

1. Open the project folder:
   ```sh
   $ code my-luminus-shadow
   ```
1. VS Code should offer you a button to select a workspace, click it and select **Client-my-luminus-shadow**.
1. Use the Calva command **Start a Project REPL and Connect (aka Jack-in)**: `ctrl+alt+c ctrl+alt+j` and wait for the _Terminal_ **Calva Jack-in** output to say `[:app] Build completed.`
1. Open http://0.0.0.0:3000 in your web browser and start hacking.


## Server and Figwheel

As with the server only, the workflow here is really just: Jack-in and start hacking. The first time it involves these steps:

0. If you haven't created the project yet, create a new server only Luminus project. E.g.:
    ```sh
    $ lein new luminus my-fw
    ```
0. This creates the folder `my-fw`. Open it in VS Code:
    ```sh
    $ code my-fw
    ```
0. Use the Calva command **Start a Project REPL and Connect (aka Jack-in)**: `ctrl+alt+c ctrl+alt+j`, select **Server + Client - my-fw** in the _Project type_ picker menu, and wait for the web app to pop open in your web browser.
0. Start hacking.

If you rather open the web app yourself, open `.vscode/settings.json` and change `"shouldOpenUrl"` to `false` in the preconfigured Calva connect sequence.

## Etcetera

You will have three Calva _Custom Command Snippets_ configured. Invoke them by issuing the **Run Custom REPL Command**, `ctrl+alt+c .` (that's a dot). The commands control the Luminus server:

1. `Start <project> Server`
2. `Stop <project> Server`
3. `Restart <project> Server`

When used, Calva will open its REPL window and excute the command, if it is not already opened. You can close this window if you prefer to use the REPL directly from the Clojure files.

Calva also opens the REPL window, and starts the Luminus server, as part of the Jack-in process.
