### PR TITLE
Fix Calva settings for Figwheel to use 127.0.0.1

### DIFF
--- a/resources/leiningen/new/luminus/calva/figwheel-settings.json
+++ b/resources/leiningen/new/luminus/calva/figwheel-settings.json
@@ -8,7 +8,7 @@
             "afterCLJReplJackInCode": "(start)",
             "cljsType": {
                 "dependsOn": "lein-figwheel",
-                "connectCode": "(do (println (str \"Starting Fighweel. Client URL is http://0.0.0.0:\" (:port (clojure.edn/read-string (slurp \"dev-config.edn\"))))) (use 'figwheel-sidecar.repl-api) (when-not (figwheel-sidecar.repl-api/figwheel-running?) (figwheel-sidecar.repl-api/start-figwheel!)) (figwheel-sidecar.repl-api/cljs-repl))",
+                "connectCode": "(do (println (str \"Starting Fighweel. Client URL is http://127.0.0.1:\" (:port (clojure.edn/read-string (slurp \"dev-config.edn\"))))) (use 'figwheel-sidecar.repl-api) (when-not (figwheel-sidecar.repl-api/figwheel-running?) (figwheel-sidecar.repl-api/start-figwheel!)) (figwheel-sidecar.repl-api/cljs-repl))",
                 "isConnectedRegExp": "To quit, type: :cljs/quit",
                 "openUrlRegExp": "Client URL is (?<url>\\S+)",
                 "shouldOpenUrl": true,


### PR DESCRIPTION
This makes the template's included Calva settings for Figwheel promote the 127.0.0.1 interface instead of 0.0.0.0, which [doesn't work on WSL 1](https://www.reddit.com/r/Clojure/comments/fj1rbi/how_to_use_calva_with_luminus/fkxqj5c?utm_source=share&utm_medium=web2x)