### PR TITLE
Fix HTTP Kit home page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ However, if you would like to attach further functionality to your template you 
 ### alternative servers
 
 * `+aleph` adds the [Aleph](https://github.com/ztellman/aleph) server
-* `+http-kit` adds the fast [HTTP Kit](http://www.http-kit.org/) web server to the project
+* `+http-kit` adds the fast [HTTP Kit](https://http-kit.github.io/) web server to the project
 * `+immutant` adds the [immutant](https://github.com/immutant/immutant) web server to the project. Note: this project is no longer funded/maintained
 * `+undertow` adds the [ring-undertow](https://github.com/luminus-framework/ring-undertow-adapter) web server to the project
 


### PR DESCRIPTION
kttp-kit.org appears to be parked