### PR TITLE
Update README - Undertow is now the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ However, if you would like to attach further functionality to your template you 
 * `+aleph` adds the [Aleph](https://github.com/ztellman/aleph) server
 * `+http-kit` adds the fast [HTTP Kit](https://github.com/http-kit/http-kit) web server to the project
 * `+immutant` adds the [immutant](https://github.com/immutant/immutant) web server to the project. Note: this project is no longer funded/maintained
-* `+undertow` adds the [ring-undertow](https://github.com/luminus-framework/ring-undertow-adapter) web server to the project
+* `+jetty` adds the [jetty](https://github.com/luminus-framework/luminus-jetty) web server to the project
 
-The default server is [jetty](https://github.com/luminus-framework/luminus-jetty) 
+The default server is [ring-undertow](https://github.com/luminus-framework/ring-undertow-adapter) 
 
 ### databases
 


### PR DESCRIPTION
[Referenced issue](https://github.com/luminus-framework/luminus-template/issues/492#issuecomment-655592787) 