### PR TITLE
Fix lein eastwood warning in HugSQL

### DIFF
--- a/resources/leiningen/new/luminus/db/test/db/core.clj
+++ b/resources/leiningen/new/luminus/db/test/db/core.clj
@@ -25,7 +25,8 @@
                :first_name "Sam"
                :last_name  "Smith"
                :email      "sam.smith@example.com"
-               :pass       "pass"})))
+               :pass       "pass"}
+              {})))
     (is (= {:id         "1"
             :first_name "Sam"
             :last_name  "Smith"
@@ -34,4 +35,4 @@
             :admin      nil
             :last_login nil
             :is_active  nil}
-           (db/get-user t-conn {:id "1"})))))
+           (db/get-user t-conn {:id "1"} {})))))


### PR DESCRIPTION
>== Linting app.test.db.core ==
>test/clj/app/test/db/core.clj:22:15: wrong-arity: Function on var #'app.db.core/create-user! called with 2 args, but it is only known to take one of the following args: []  [params]  [db params options & command-options]
>test/clj/app/test/db/core.clj:37:13: wrong-arity: Function on var #'app.db.core/get-user called with 2 args, but it is only known to take one of the following args: []  [params]  [db params options & command-options]

This 3rd argument(options) is an optional hashmap of HugSQL-specific options (e.g., <code>:quoting</code> and <code>:adapter</code>)
Reference: https://github.com/layerware/hugsql/blob/master/docs/hugsql.org/index.html#L301

It is trivial but it removes the warnings when running the tests + fixes `lein eastwood` warnings for new installations:

>== Warnings: 0 (not including reflection warnings)  Exceptions thrown: 0