### PR TITLE
Remove extra 'test' path

### DIFF
--- a/resources/leiningen/new/luminus/core/test/handler_test.clj
+++ b/resources/leiningen/new/luminus/core/test/handler_test.clj
@@ -1,4 +1,4 @@
-(ns <<project-ns>>.test.handler-test
+(ns <<project-ns>>.handler-test
   (:require
     [clojure.test :refer :all]
     [ring.mock.request :refer :all]

--- a/resources/leiningen/new/luminus/db/test/db/core_test.clj
+++ b/resources/leiningen/new/luminus/db/test/db/core_test.clj
@@ -1,4 +1,4 @@
-(ns <<project-ns>>.test.db.core-test
+(ns <<project-ns>>.db.core-test
   (:require
    [<<project-ns>>.db.core :refer [*db*] :as db]
    [java-time.pre-java8]

--- a/src/leiningen/new/db.clj
+++ b/src/leiningen/new/db.clj
@@ -39,7 +39,7 @@
     (concat
       [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/sql.db.clj"]
        ["{{resource-path}}/sql/queries.sql" "db/sql/queries.sql"]
-       ["{{backend-test-path}}/{{sanitized}}/test/db/core_test.clj" "db/test/db/core_test.clj"]]
+       ["{{backend-test-path}}/{{sanitized}}/db/core_test.clj" "db/test/db/core_test.clj"]]
       (when (some #{"+expanded"} (:features options))
         [[(str "{{resource-path}}/migrations/" timestamp "-add-users-table.up.sql") "db/migrations/add-users-table.up.sql"]
          [(str "{{resource-path}}/migrations/" timestamp "-add-users-table.down.sql") "db/migrations/add-users-table.down.sql"]]))))

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -81,7 +81,7 @@
    "{{resource-path}}/public/js"
 
    ;; tests
-   ["{{backend-test-path}}/{{sanitized}}/test/handler_test.clj" "core/test/handler_test.clj"]])
+   ["{{backend-test-path}}/{{sanitized}}/handler_test.clj" "core/test/handler_test.clj"]])
 
 (def binary-assets
   [["{{resource-path}}/public/favicon.ico" "core/resources/favicon.ico"]


### PR DESCRIPTION
CIDER finds tests in the 'test' root folder,
using a naming convention of 'foo-test' for the class.