### PR TITLE
Remove unused requires

### DIFF
--- a/resources/leiningen/new/luminus/core/src/formats.clj
+++ b/resources/leiningen/new/luminus/core/src/formats.clj
@@ -1,6 +1,5 @@
 (ns <<project-ns>>.middleware.formats
   (:require
-    [cognitect.transit :as transit]
     [luminus-transit.time :as time]
     [muuntaja.core :as m]))
 

--- a/resources/leiningen/new/luminus/core/src/middleware.clj
+++ b/resources/leiningen/new/luminus/core/src/middleware.clj
@@ -1,8 +1,6 @@
 (ns <<project-ns>>.middleware
   (:require
     [<<project-ns>>.env :refer [defaults]]<% if not service %>
-    [cheshire.generate :as cheshire]
-    [cognitect.transit :as transit]
     [clojure.tools.logging :as log]
     [<<project-ns>>.layout :refer [error-page]]
     [ring.middleware.anti-forgery :refer [wrap-anti-forgery]]


### PR DESCRIPTION
These requires seem to use `:as` aliases, but are never used.