### PR TITLE
get rid of type infer warning

### DIFF
--- a/resources/leiningen/new/luminus/reagent/src/cljs/core.cljs
+++ b/resources/leiningen/new/luminus/reagent/src/cljs/core.cljs
@@ -75,7 +75,7 @@
   (doto (History.)
     (events/listen
       HistoryEventType/NAVIGATE
-      (fn [event]
+      (fn [^js/Event.token event]
         (swap! session assoc :page (match-route (.-token event)))))
     (.setEnabled true)))
 


### PR DESCRIPTION
got a warning: "Cannot infer target type in expression (. event -token)" on recompile -> looked at https://clojurescript.org/guides/externs
------
to get rid of the warning use this fix
or set this in your file
```(set! *warn-on-infer* false)```