### PR TITLE
Added select keys to http start

### DIFF
--- a/resources/leiningen/new/luminus/core/src/core.clj
+++ b/resources/leiningen/new/luminus/core/src/core.clj
@@ -28,7 +28,8 @@
     (-> env<% if undertow-based %>
         (update :io-threads #(or % (* 2 (.availableProcessors (Runtime/getRuntime))))) <% endif %>
         (assoc  :handler (handler/app))
-        (update :port #(or (-> env :options :port) %))))
+        (update :port #(or (-> env :options :port) %))
+        (select-keys [:handler :host :port])))
   :stop
   (http/stop http-server))
 
@@ -86,5 +87,5 @@
       (migrations/migrate args (select-keys env [:database-url]))
       (System/exit 0))
     :else
-    (start-app args)))
+    (start-app args))
   <% else %>(start-app args))<% endif %>

--- a/resources/leiningen/new/luminus/core/src/core.clj
+++ b/resources/leiningen/new/luminus/core/src/core.clj
@@ -87,5 +87,5 @@
       (migrations/migrate args (select-keys env [:database-url]))
       (System/exit 0))
     :else
-    (start-app args))
+    (start-app args)))
   <% else %>(start-app args))<% endif %>


### PR DESCRIPTION
Hi maintainers, this is a follow up for the [issue](https://github.com/luminus-framework/luminus/issues/277) I opened several days ago in `luminus`, where the environment variable `IP` prevented connection to `localhost:3000` in a fresh template.

I've added the `select-keys` and verified manually that it doesn't break any of:

```
lein new luminus app
lein new luminus app +immutant
lein new luminus app +aleph
lein new luminus app +undertow
```

and that it works with `lein new luminus app +http-kit` even though I've got the `IP` environment variable set.

Please let me know if you'd like to add or change anything.