### PR TITLE
Fix broken Calva config causing the server start code to fail

### DIFF
--- a/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
+++ b/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
@@ -1,7 +1,7 @@
         {
             "name": "Server only - <<name>>",
             "projectType": "Leiningen",
-            "afterCLJReplJackInCode": "(start)",
+            "afterCLJReplJackInCode": "(in-ns 'user) (start)",
             "cljsType": "none",
             "menuSelections": {
                 "leinProfiles": [


### PR DESCRIPTION
Ensure user ns when Calva starts the server as part of the connect sequence.