### PR TITLE
Remove http-server reload noop setting

### DIFF
--- a/resources/leiningen/new/luminus/core/src/core.clj
+++ b/resources/leiningen/new/luminus/core/src/core.clj
@@ -22,7 +22,7 @@
   [["-p" "--port PORT" "Port number"
     :parse-fn #(Integer/parseInt %)]])
 
-(mount/defstate ^{:on-reload :noop} http-server
+(mount/defstate http-server
   :start
   (http/start
     (-> env<% if undertow-based %>


### PR DESCRIPTION
This causes issues with Aleph (didn't test other servers) where route changes won't be picked up.