### PR TITLE
For the nav-link, subscribe to :common/page-id

### DIFF
--- a/resources/leiningen/new/luminus/reframe/src/cljs/core.cljs
+++ b/resources/leiningen/new/luminus/reframe/src/cljs/core.cljs
@@ -17,7 +17,7 @@
 (defn nav-link [uri title page]
   [:a<% if expanded %>.navbar-item<% endif %>
    {:href   uri
-    :class (when (= page @(rf/subscribe [:common/page])) :is-active)}
+    :class (when (= page @(rf/subscribe [:common/page-id])) :is-active)}
    title])
 
 (defn navbar [] <% if expanded %>


### PR DESCRIPTION
This way the nav-link properly gets the :is-active class where appropriate