### PR TITLE
Update Calva settings to ensure ns user

### DIFF
--- a/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
+++ b/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
@@ -1,7 +1,7 @@
         {
             "name": "Server only - <<name>>",
             "projectType": "Leiningen",
-            "afterCLJReplJackInCode": "(in-ns 'user) (start)",
+            "afterCLJReplJackInCode": "(in-ns 'user) (start) (println \"Access the server at http://localhost:3000\")",
             "cljsType": "none",
             "menuSelections": {
                 "leinProfiles": [

--- a/resources/leiningen/new/luminus/calva/shadow-settings.json
+++ b/resources/leiningen/new/luminus/calva/shadow-settings.json
@@ -5,7 +5,7 @@
         {
             "name": "Server + Client – <<name>>",
             "projectType": "lein-shadow",
-            "afterCLJReplJackInCode": "(start)",
+            "afterCLJReplJackInCode": "(in-ns 'user) (start) (println \"Access the server at http://localhost:3000\")",
             "cljsType": "shadow-cljs",
             "menuSelections": {
                 "leinProfiles": [


### PR DESCRIPTION
I got comments on this Youtube video https://www.youtube.com/watch?v=0zaGtbc-5oc that the instructions where no longer working.

I don't know what else has changed but the fix is to ensure the server auto start command is issued in the `user` namespace.

While at it I print a message informing where to point the browser.