### PR TITLE
Suggest running 'shadow-cljs watch app' instead of 'lein shadow watch app'

### DIFF
--- a/resources/leiningen/new/luminus/cljs/resources/html/home.html
+++ b/resources/leiningen/new/luminus/cljs/resources/html/home.html
@@ -13,7 +13,7 @@
           <div class="content">
             <h4 class="title">Welcome to <<name>></h4>
             <p>If you're seeing this message, that means you haven't yet compiled your ClojureScript!</p><% if not boot %>
-            <p>Please run <code><% if shadow-cljs %>lein shadow watch app<% else %>lein figwheel<% endif %></code> to start the ClojureScript compiler and reload the page.</p><% else %>
+            <p>Please run <code><% if shadow-cljs %>shadow-cljs watch app<% else %>lein figwheel<% endif %></code> to start the ClojureScript compiler and reload the page.</p><% else %>
             <p>Please close this process and start the server with <code>boot figwheel</code> to enable the ClojureScript compiler.<% endif %>
             <h4>For better ClojureScript development experience in Chrome follow these steps:</h4>
             <ul>


### PR DESCRIPTION
The lein-shadow plugin was removed from the template, but the information page for starting the cljs development process still referenced it. 

This was clarified in #532 