### PR TITLE
Update Calva config to change away from lein-shadow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 4.10
+- reagent 1.1.0
+- switched to shadow-cljs as the default for ClojureScript
+- org.xerial/sqlite-jdbc 3.34.0
+- org.webjars.npm/material-icons 0.7.0
+- org.webjars/webjars-locator 0.41
+
 ## 4.09
 - ClojureScript 1.10.866
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 4.11
+- [fix for cider-nrepl in dev profile](https://github.com/luminus-framework/luminus-template/issues/534)
+
 ## 4.10
 - reagent 1.1.0
 - switched to shadow-cljs as the default for ClojureScript

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 4.08
+- [Update Calva settings to ensure ns user](https://github.com/luminus-framework/luminus-template/pull/531)
+
 ## 4.07
 - [`+crux` option for adding Crux support](https://github.com/luminus-framework/luminus-template/pull/530)
 - selmer 1.12.40

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 4.13
+- fix for imports needed by +auth-jwe profile
+
 ## 4.12
 - removed package.json and shadow-cljs.edn from .gitignore
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 4.09
+- ClojureScript 1.10.866
+
 ## 4.08
 - [Update Calva settings to ensure ns user](https://github.com/luminus-framework/luminus-template/pull/531)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 4.12
+- removed package.json and shadow-cljs.edn from .gitignore
+
 ## 4.11
 - [fix for cider-nrepl in dev profile](https://github.com/luminus-framework/luminus-template/issues/534)
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/lein-template "4.07"
+(defproject luminus/lein-template "4.08"
   :description "a template for creating Luminus applications"
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/lein-template "4.08"
+(defproject luminus/lein-template "4.09"
   :description "a template for creating Luminus applications"
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/lein-template "4.12"
+(defproject luminus/lein-template "4.13"
   :description "a template for creating Luminus applications"
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/lein-template "4.11"
+(defproject luminus/lein-template "4.12"
   :description "a template for creating Luminus applications"
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/lein-template "4.09"
+(defproject luminus/lein-template "4.10"
   :description "a template for creating Luminus applications"
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/lein-template "4.10"
+(defproject luminus/lein-template "4.11"
   :description "a template for creating Luminus applications"
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"

--- a/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
+++ b/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
@@ -1,5 +1,5 @@
         {
-            "name": "Server only - <<name>>",
+            "name": "<<name>> Server",
             "projectType": "Leiningen",
             "afterCLJReplJackInCode": "(in-ns 'user) (start) (println \"Access the server at http://localhost:3000\")",
             "cljsType": "none",

--- a/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
+++ b/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
@@ -1,7 +1,7 @@
         {
             "name": "Server only - <<name>>",
             "projectType": "Leiningen",
-            "afterCLJReplJackInCode": "(in-ns 'user) (start)",
+            "afterCLJReplJackInCode": "(in-ns 'user) (start) (println \"Access the server at http://localhost:3000\")",
             "cljsType": "none",
             "menuSelections": {
                 "leinProfiles": [

--- a/resources/leiningen/new/luminus/calva/shadow-settings.json
+++ b/resources/leiningen/new/luminus/calva/shadow-settings.json
@@ -3,14 +3,11 @@
     "calva.replConnectSequences": [
         <% include calva/server-connect-sequence-fragment.json %>,
         {
-            "name": "Server + Client – <<name>>",
-            "projectType": "lein-shadow",
+            "name": "<<name>> Server + Client",
+            "projectType": "shadow-cljs",
             "afterCLJReplJackInCode": "(in-ns 'user) (start) (println \"Access the server at http://localhost:3000\")",
             "cljsType": "shadow-cljs",
             "menuSelections": {
-                "leinProfiles": [
-                    "dev"
-                ],
                 "cljsLaunchBuilds": [
                     "app",
                     "test"

--- a/resources/leiningen/new/luminus/calva/shadow-settings.json
+++ b/resources/leiningen/new/luminus/calva/shadow-settings.json
@@ -5,7 +5,7 @@
         {
             "name": "Server + Client – <<name>>",
             "projectType": "lein-shadow",
-            "afterCLJReplJackInCode": "(start)",
+            "afterCLJReplJackInCode": "(in-ns 'user) (start) (println \"Access the server at http://localhost:3000\")",
             "cljsType": "shadow-cljs",
             "menuSelections": {
                 "leinProfiles": [

--- a/resources/leiningen/new/luminus/cljs/resources/html/home.html
+++ b/resources/leiningen/new/luminus/cljs/resources/html/home.html
@@ -13,7 +13,7 @@
           <div class="content">
             <h4 class="title">Welcome to <<name>></h4>
             <p>If you're seeing this message, that means you haven't yet compiled your ClojureScript!</p><% if not boot %>
-            <p>Please run <code><% if shadow-cljs %>lein shadow watch app<% else %>lein figwheel<% endif %></code> to start the ClojureScript compiler and reload the page.</p><% else %>
+            <p>Please run <code><% if shadow-cljs %>shadow-cljs watch app<% else %>lein figwheel<% endif %></code> to start the ClojureScript compiler and reload the page.</p><% else %>
             <p>Please close this process and start the server with <code>boot figwheel</code> to enable the ClojureScript compiler.<% endif %>
             <h4>For better ClojureScript development experience in Chrome follow these steps:</h4>
             <ul>

--- a/resources/leiningen/new/luminus/core/README.md
+++ b/resources/leiningen/new/luminus/core/README.md
@@ -1,6 +1,6 @@
 # <<name>>
 
-generated using Luminus version "4.12"
+generated using Luminus version "4.13"
 
 FIXME
 

--- a/resources/leiningen/new/luminus/core/README.md
+++ b/resources/leiningen/new/luminus/core/README.md
@@ -1,6 +1,6 @@
 # <<name>>
 
-generated using Luminus version "4.08"
+generated using Luminus version "4.09"
 
 FIXME
 

--- a/resources/leiningen/new/luminus/core/README.md
+++ b/resources/leiningen/new/luminus/core/README.md
@@ -1,6 +1,6 @@
 # <<name>>
 
-generated using Luminus version "4.09"
+generated using Luminus version "4.10"
 
 FIXME
 

--- a/resources/leiningen/new/luminus/core/README.md
+++ b/resources/leiningen/new/luminus/core/README.md
@@ -1,6 +1,6 @@
 # <<name>>
 
-generated using Luminus version "4.11"
+generated using Luminus version "4.12"
 
 FIXME
 

--- a/resources/leiningen/new/luminus/core/README.md
+++ b/resources/leiningen/new/luminus/core/README.md
@@ -1,6 +1,6 @@
 # <<name>>
 
-generated using Luminus version "4.07"
+generated using Luminus version "4.08"
 
 FIXME
 

--- a/resources/leiningen/new/luminus/core/README.md
+++ b/resources/leiningen/new/luminus/core/README.md
@@ -1,6 +1,6 @@
 # <<name>>
 
-generated using Luminus version "4.10"
+generated using Luminus version "4.11"
 
 FIXME
 

--- a/resources/leiningen/new/luminus/core/gitignore
+++ b/resources/leiningen/new/luminus/core/gitignore
@@ -11,9 +11,7 @@ test-config.edn
 profiles.clj
 /.env
 .nrepl-port
-<% if shadow-cljs %>/.shadow-cljs
-package.json
-shadow-cljs.edn<% endif %>
+<% if shadow-cljs %>/.shadow-cljs<% endif %>
 /node_modules
 /log
 <% if crux %>/data<% endif %>

--- a/resources/leiningen/new/luminus/core/project.clj
+++ b/resources/leiningen/new/luminus/core/project.clj
@@ -25,16 +25,16 @@
   <<uberwar-options>><% endif %><% if clean-targets %>
   :clean-targets ^{:protect false}
   <<clean-targets>><% endif %><% if cljs %>
-  <% if shadow-cljs %>:shadow-cljs
-  <<shadow-cljs-config>>
-  :npm-deps [<<npm-deps>>]
-  :npm-dev-deps <<npm-dev-deps>><% else %>:figwheel
+  <% if figwheel %>:figwheel
   <<figwheel>><% endif %><% endif %>
 
   :profiles
   {:uberjar {:omit-source true<% if cljs %>
-             <<cljs-uberjar-prep>>
-             <% if not shadow-cljs %>:cljsbuild<% endif %><<uberjar-cljsbuild>><% endif %>
+             <% if shadow-cljs %>
+             <<shadow-uberjar-prep>><% else %>
+             <<figwheel-uberjar-prep>>
+             :cljsbuild
+             <<uberjar-cljsbuild>><% endif %><% endif %>
              :aot :all
              :uberjar-name "<<name>>.jar"
              :source-paths ["env/prod/clj" <% if shadow-cljs %> "env/prod/cljs" <% endif %>]
@@ -46,7 +46,8 @@
    :project/dev  {:jvm-opts ["-Dconf=dev-config.edn" <% for opt in opts %> <<opt>><% endfor %>]
                   :dependencies [<<dev-dependencies>>]
                   :plugins      [<<dev-plugins>>] <% if cljs %>
-                  <% if not shadow-cljs %>:cljsbuild<% endif %><<dev-cljsbuild>><% endif %>
+                  <% if not shadow-cljs %>:cljsbuild
+                  <<dev-cljsbuild>><% endif %><% endif %>
                   <% if cljs-test %><% if not shadow-cljs %>
                   :doo <<cljs-test>><% endif %><% endif %>
                   :source-paths ["env/dev/clj" <% if shadow-cljs %> "env/dev/cljs" "test/cljs" <% endif %>]

--- a/resources/leiningen/new/luminus/core/src/middleware.clj
+++ b/resources/leiningen/new/luminus/core/src/middleware.clj
@@ -14,10 +14,10 @@
     [ring.middleware.defaults :refer [site-defaults wrap-defaults]]<% if auth-middleware-required %>
     <<auth-middleware-required>><% if auth-session %>
     <<auth-session>><% endif %><% if auth-jwe %>
-    <<auth-jwe>>[buddy.sign.util :refer [to-timestamp]]<% endif %><% endif %>)<% if not service %>
+    <<auth-jwe>>[buddy.sign.util :refer [to-timestamp]]<% endif %><% endif %>)
   <% if any auth-jwe servlet %> (:import
     <% if auth-jwe %>[java.util Calendar Date]<% endif %>
-    <% if servlet %>[javax.servlet ServletContext]<% endif %>)<% endif %><% endif %>)
+    <% if servlet %>[javax.servlet ServletContext]<% endif %>)<% endif %>)
 <% if not service %><% if servlet %>
 (defn wrap-context [handler]
   (fn [request]

--- a/resources/leiningen/new/luminus/shadow/package.json
+++ b/resources/leiningen/new/luminus/shadow/package.json
@@ -1,0 +1,9 @@
+{
+  "devDependencies": {
+    "shadow-cljs": "^2.14.3"
+  },
+  "dependencies":{<% if reagent %>
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  <% endif %>}
+}

--- a/resources/leiningen/new/luminus/shadow/shadow-cljs.edn
+++ b/resources/leiningen/new/luminus/shadow/shadow-cljs.edn
@@ -11,4 +11,4 @@
                 :release    {}}
          :test {:target  :node-test, :output-to "target/test/test.js"
                 :autorun true}}
- :lein  true}
+ :lein  {:profile "+dev"}}

--- a/resources/leiningen/new/luminus/shadow/shadow-cljs.edn
+++ b/resources/leiningen/new/luminus/shadow/shadow-cljs.edn
@@ -1,0 +1,14 @@
+{:nrepl {:port 7002}
+ :builds
+        {:app
+               {:target     :browser
+                :output-dir "target/cljsbuild/public/js"
+                :asset-path "/js"
+                :modules    {:app {:entries [<<project-ns>>.app]}}
+                <% if re-frame %>:devtools   {:watch-dir "resources/public"
+                             :preloads  [re-frisk.preload]}
+                :dev        {:closure-defines {"re_frame.trace.trace_enabled_QMARK_" true}}<% endif %>
+                :release    {}}
+         :test {:target  :node-test, :output-to "target/test/test.js"
+                :autorun true}}
+ :lein  true}

--- a/src/leiningen/new/cljs.clj
+++ b/src/leiningen/new/cljs.clj
@@ -15,7 +15,7 @@
             [["{{client-test-path}}/{{sanitized}}/doo_runner.cljs" "cljs/test/cljs/doo_runner.cljs"]
              ["env/dev/clj/{{sanitized}}/figwheel.clj" "cljs/env/dev/clj/figwheel.clj"]])))
 
-(def cljs-version "1.10.844")
+(def cljs-version "1.10.866")
 
 (def figwheel-version "0.5.20")
 

--- a/src/leiningen/new/db.clj
+++ b/src/leiningen/new/db.clj
@@ -18,7 +18,7 @@
           :mysql    [['mysql/mysql-connector-java "8.0.18"]
                      ['com.google.protobuf/protobuf-java "3.8.0"]]
           :h2       [['com.h2database/h2 "1.4.200"]]
-          :sqlite   [['org.xerial/sqlite-jdbc "3.32.3"]]}
+          :sqlite   [['org.xerial/sqlite-jdbc "3.34.0"]]}
          (select-db options))))
 
 (defn db-url [{:keys [sanitized] :as options} suffix]

--- a/src/leiningen/new/expanded.clj
+++ b/src/leiningen/new/expanded.clj
@@ -5,9 +5,9 @@
   [['markdown-clj "1.10.5"]
    ['funcool/struct "1.4.0"]
    ['org.webjars.npm/bulma "0.9.2"]
-   ['org.webjars.npm/material-icons "0.3.1"]
+   ['org.webjars.npm/material-icons "0.7.0"]
    ['ring-webjars "0.2.0"]
-   ['org.webjars/webjars-locator "0.40"]])
+   ['org.webjars/webjars-locator "0.41"]])
 
 (def expanded-assets
   [["{{resource-path}}/public/css/screen.css" "expanded/resources/css/screen.css"]

--- a/src/leiningen/new/figwheel.clj
+++ b/src/leiningen/new/figwheel.clj
@@ -1,0 +1,45 @@
+(ns leiningen.new.figwheel
+  (:require
+    [leiningen.new.cljs :refer [dev-cljsbuild uberjar-cljsbuild test-cljsbuild]]
+    [leiningen.new.common :refer :all]
+    [clojure.string :refer [join]]))
+
+(def doo-version "0.1.11")
+(def figwheel-version "0.5.20")
+
+(def figwheel
+  {:http-server-root "public"
+   :server-logfile "log/figwheel-logfile.log"
+   :nrepl-port       7002
+   :css-dirs         ["resources/public/css"]
+   :nrepl-middleware `[cider.piggieback/wrap-cljs-repl]})
+
+(def figwheel-assets
+  [["{{client-test-path}}/{{sanitized}}/doo_runner.cljs" "cljs/test/cljs/doo_runner.cljs"]
+   ["env/dev/clj/{{sanitized}}/figwheel.clj" "cljs/env/dev/clj/figwheel.clj"]])
+
+(def figwheel-dev-plugins
+  [['lein-doo doo-version]
+   ['lein-figwheel figwheel-version]])
+
+(def figwheel-plugins
+  [['lein-cljsbuild "1.1.7"]])
+
+(def figwheel-dev-dependencies
+  [['figwheel-sidecar figwheel-version]])
+
+(defn figwheel-features [[assets options :as state]]
+  (if (some #{"+figwheel"} (:features options))
+    [(into assets figwheel-assets)
+     (-> options
+         (assoc :figwheel true
+                :figwheel-uberjar-prep ":prep-tasks [\"compile\" [\"cljsbuild\" \"once\" \"min\"]]")
+         (merge
+           {:figwheel (indent root-indent (figwheel options))
+            :dev-cljsbuild (indent dev-indent (dev-cljsbuild options))
+            :test-cljsbuild (indent dev-indent (test-cljsbuild options))
+            :uberjar-cljsbuild (indent uberjar-indent (uberjar-cljsbuild options))})
+         (append-options :plugins figwheel-plugins)
+         (append-options :dev-plugins figwheel-dev-plugins)
+         (append-options :dev-dependencies figwheel-dev-dependencies))]
+    state))

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -145,7 +145,8 @@
 
 (def core-dev-plugins
   [['com.jakemccrary/lein-test-refresh "0.24.1"]
-   ['jonase/eastwood "0.3.5"]])
+   ['jonase/eastwood "0.3.5"]
+   ['cider/cider-nrepl "0.26.0"]])
 
 (defn generate-project
   "Create a new Luminus project"

--- a/src/leiningen/new/reagent.clj
+++ b/src/leiningen/new/reagent.clj
@@ -6,8 +6,12 @@
    ["{{client-path}}/{{sanitized}}/ajax.cljs" "reagent/src/cljs/ajax.cljs"]])
 
 (defn reagent-dependencies [{:keys [features]}]
-  [['reagent "1.0.0"]
-   ['cljs-ajax "0.8.3"]])
+  (into
+    [['reagent "1.1.0"]
+     ['cljs-ajax "0.8.3"]]
+    (when (some #{"+figwheel"} features)
+      [['cljsjs/react "17.0.2-0"]
+       ['cljsjs/react-dom "17.0.2-0"]])))
 
 (defn reagent-features [[assets options :as state]]
   (if (some #{"+reagent"} (:features options))

--- a/src/leiningen/new/shadow_cljs.clj
+++ b/src/leiningen/new/shadow_cljs.clj
@@ -1,40 +1,14 @@
 (ns leiningen.new.shadow-cljs
   (:require [leiningen.new.common :refer :all]))
 
-(def shadow-version "2.12.1")
+(def shadow-version "2.14.3")
 
-(def shadow-cljs-dependencies [['com.google.javascript/closure-compiler-unshaded "v20200504" :scope "provided"]
-                               ['org.clojure/google-closure-library "0.0-20191016-6ae1f72f" :scope "provided"]
-                               #_['org.clojure/google-closure-library-third-party "0.0-20191016-6ae1f72f" :scope "provided"]
-                               ['thheller/shadow-cljs shadow-version :scope "provided"]
-                               ['org.clojure/core.async "1.3.610"]])
+(def shadow-cljs-dependencies [['thheller/shadow-cljs shadow-version :scope "provided"]
+                               ['org.clojure/core.async "1.3.618"]])
 
-(def shadow-cljs-plugins [['lein-shadow "0.2.0"]])
-
-(defn project-ns-symbol [project-ns suffix]
-  (read-string (str project-ns suffix)))
-
-;; Goal was to reproduce the same profiles as leiningen/cljsbuild approach
-(defn shadow-cljs-config [{:keys [features project-ns]}]
-  {:nrepl
-   {:port 7002}
-
-   :builds
-   {:app  (merge
-           {:target     :browser
-            :output-dir "target/cljsbuild/public/js"
-            :asset-path "/js"
-            :modules    {:app
-                         {:entries [(project-ns-symbol project-ns ".app")]}}
-            :devtools   (merge {:watch-dir "resources/public"}
-                               (when (some #{"+re-frame"} features)
-                                 {:preloads ['re-frisk.preload #_'day8.re-frame-10x.preload]}))}
-           (when (some #{"+re-frame"} features)
-             {:dev {:closure-defines {"re_frame.trace.trace_enabled_QMARK_" true}}}))
-
-    :test {:target    :node-test
-           :output-to "target/test/test.js"
-           :autorun   true}}})
+(def shadow-assets
+  [["package.json" "shadow/package.json"]
+   ["shadow-cljs.edn" "shadow/shadow-cljs.edn"]])
 
 ;; TODO: Hoplon?
 (defn npm-deps [{:keys [features]}]
@@ -48,13 +22,13 @@
 
 (defn shadow-cljs-features [[assets options :as state]]
   (if (some #{"+shadow-cljs"} (:features options))
-    [assets
+    [(into assets shadow-assets)
      (-> options
+         (update :plugins (fnil conj []) ['lein-shell "0.5.0"])
          (assoc :shadow-cljs true
-                :shadow-cljs-config (indent root-indent (shadow-cljs-config options))
+                :shadow-uberjar-prep ":prep-tasks [\"compile\" [\"shell\" \"shadow-cljs\" \"release\" \"app\"]]"
                 :npm-dev-deps [['xmlhttprequest "1.8.0"]]
                 :npm-deps (indent require-indent (npm-deps options)))
-         (append-options :plugins shadow-cljs-plugins)
          (append-options :dependencies shadow-cljs-dependencies))]
     state))
 


### PR DESCRIPTION
I've updated the **Client + Server** jack-in configuration to plain `shadow-cljs`.

I also changed the shadow-cljs config to include the Leiningen project's `dev` profile. I've checked that this does not impact the release build of the client app with Thomas Heller, who gave me this to read: https://code.thheller.com/blog/shadow-cljs/2018/02/08/problem-solved-source-paths.html Let me know if you want this in a separate PR, or not at all.

I don't know why the PR got a bit messy. Can you take it like this, or should I clean it up?
