### PR TITLE
Update Calva config from lein-shadow to shadow-cljs project type

### DIFF
--- a/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
+++ b/resources/leiningen/new/luminus/calva/server-connect-sequence-fragment.json
@@ -1,5 +1,5 @@
         {
-            "name": "Server only - <<name>>",
+            "name": "<<name>> Server",
             "projectType": "Leiningen",
             "afterCLJReplJackInCode": "(in-ns 'user) (start) (println \"Access the server at http://localhost:3000\")",
             "cljsType": "none",

--- a/resources/leiningen/new/luminus/calva/shadow-settings.json
+++ b/resources/leiningen/new/luminus/calva/shadow-settings.json
@@ -3,14 +3,11 @@
     "calva.replConnectSequences": [
         <% include calva/server-connect-sequence-fragment.json %>,
         {
-            "name": "Server + Client – <<name>>",
-            "projectType": "lein-shadow",
+            "name": "<<name>> Server + Client",
+            "projectType": "shadow-cljs",
             "afterCLJReplJackInCode": "(in-ns 'user) (start) (println \"Access the server at http://localhost:3000\")",
             "cljsType": "shadow-cljs",
             "menuSelections": {
-                "leinProfiles": [
-                    "dev"
-                ],
                 "cljsLaunchBuilds": [
                     "app",
                     "test"

--- a/resources/leiningen/new/luminus/shadow/shadow-cljs.edn
+++ b/resources/leiningen/new/luminus/shadow/shadow-cljs.edn
@@ -11,4 +11,4 @@
                 :release    {}}
          :test {:target  :node-test, :output-to "target/test/test.js"
                 :autorun true}}
- :lein  true}
+ :lein  {:profile "+dev"}}


### PR DESCRIPTION
I've updated the Client + Server jack-in configuration to plain shadow-cljs.

I also changed the shadow-cljs config to include the Leiningen project's dev profile.