### PR TITLE
Added +ctmx option

### DIFF
--- a/resources/leiningen/new/luminus/ctmx/src/home.clj
+++ b/resources/leiningen/new/luminus/ctmx/src/home.clj
@@ -1,0 +1,33 @@
+(ns <<project-ns>>.routes.home
+  (:require
+    [ctmx.core :as ctmx]
+    [ctmx.render :as render]
+    [hiccup.page :refer [html5]]))
+
+(defn html-response [body]
+  {:status 200
+   :headers {"Content-Type" "text/html"}
+   :body body})
+
+(defn html5-response
+  ([body]
+   (html-response
+    (html5
+     [:head
+      [:meta {:name "viewport"
+              :content "width=device-width, initial-scale=1, shrink-to-fit=no"}]]
+     [:body (render/walk-attrs body)]
+     [:script {:src "https://unpkg.com/htmx.org@1.5.0"}]))))
+
+(ctmx/defcomponent ^:endpoint root [req ^:int num-clicks]
+  [:div.m-3 {:hx-post "root"
+             :hx-swap "outerHTML"
+             :hx-vals {:num-clicks (inc num-clicks)}}
+   "You have clicked me " num-clicks " times."])
+
+(defn home-routes []
+  (ctmx/make-routes
+   "/"
+   (fn [req]
+     (html5-response
+      (root req 0)))))

--- a/src/leiningen/new/ctmx.clj
+++ b/src/leiningen/new/ctmx.clj
@@ -5,7 +5,6 @@
   [["{{backend-path}}/{{sanitized}}/routes/home.clj" "ctmx/src/home.clj"]])
 
 (defn ctmx-features [[assets options :as state]]
-  (println "ctmx-features" (some #{"+ctmx"} (:features options)))
   (if (some #{"+ctmx"} (:features options))
     [(into (remove-conflicting-assets assets "home.clj") ctmx-assets)
      (-> options

--- a/src/leiningen/new/ctmx.clj
+++ b/src/leiningen/new/ctmx.clj
@@ -1,0 +1,14 @@
+(ns leiningen.new.ctmx
+  (:require [leiningen.new.common :refer :all]))
+
+(def ctmx-assets
+  [["{{backend-path}}/{{sanitized}}/routes/home.clj" "ctmx/src/home.clj"]])
+
+(defn ctmx-features [[assets options :as state]]
+  (println "ctmx-features" (some #{"+ctmx"} (:features options)))
+  (if (some #{"+ctmx"} (:features options))
+    [(into (remove-conflicting-assets assets "home.clj") ctmx-assets)
+     (-> options
+         (append-options :dependencies [['ctmx "1.4.3"]])
+         (assoc :ctmx true))]
+    state))

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -9,6 +9,7 @@
             [leiningen.new.lein :refer [lein-features]]
             [leiningen.new.boot :refer [boot-features]]
             [leiningen.new.reitit :refer [reitit-features]]
+            [leiningen.new.ctmx :refer [ctmx-features]]
             [leiningen.new.auth :refer [auth-features]]
             [leiningen.new.auth-base :refer [auth-base-features]]
             [leiningen.new.auth-jwe :refer [auth-jwe-features]]
@@ -157,6 +158,7 @@
             lein-features
             boot-features
             reitit-features
+            ctmx-features
             service-features
             servlet-features
             auth-base-features
@@ -270,7 +272,7 @@
                              "+cucumber" "+sassc" "+oauth"
                              "+swagger" "+war" "+graphql"
                              "+kibit" "+service" "+servlet"
-                             "+boot" "+shadow-cljs"
+                             "+boot" "+shadow-cljs" "+ctmx"
                              "+basic" "+expanded"}
         options            (merge
                              project-relative-paths

--- a/test/test_templates.clj
+++ b/test/test_templates.clj
@@ -63,6 +63,7 @@
            "+reagent"
            "+re-frame"
            "+reitit"
+           "+ctmx"
            "+sassc"
            "+service"
            "+servlet"


### PR DESCRIPTION
Thanks for the great library, luminus is my go-to template.  Are you willing to add a +ctmx option for [ctmx](https://github.com/whamtet/ctmx)?  This PR add a single simple command line option which runs just after reitit.  It replaces the reitit generated `view/home.clj` with a very simple ctmx sample.  The sample is put into a single ns to show the simplicity of ctmx, am happy to adjust as per your suggestions.