### PR TITLE
Rename crux -> xtdb

### DIFF
--- a/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
+++ b/resources/leiningen/new/luminus/core/env/dev/resources/logback.xml
@@ -33,8 +33,8 @@
     <logger name="io.netty" level="warn" /><% endifequal %><% if undertow-based %>
     <logger name="io.undertow.websockets.core.request" level="warn" />
     <logger name="io.undertow.request" level="warn" />
-    <logger name="io.undertow.session" level="warn" /><% endif %><% if crux %>
-    <logger name="crux" level="warn" /><% endif %>
+    <logger name="io.undertow.session" level="warn" /><% endif %><% if xtdb %>
+    <logger name="xtdb" level="warn" /><% endif %>
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />

--- a/resources/leiningen/new/luminus/core/gitignore
+++ b/resources/leiningen/new/luminus/core/gitignore
@@ -14,6 +14,6 @@ profiles.clj
 <% if shadow-cljs %>/.shadow-cljs<% endif %>
 /node_modules
 /log
-<% if crux %>/data<% endif %>
+<% if xtdb %>/data<% endif %>
 <% for item in gitignore %>
 <<item>><% endfor %>

--- a/resources/leiningen/new/luminus/db/docs/crux_instructions.md
+++ b/resources/leiningen/new/luminus/db/docs/crux_instructions.md
@@ -1,6 +1,0 @@
-#### Crux configuration
-
-* Crux can be configured in the `dev-config.edn` and `test-config.edn` files. By default you will have a local Crux node in the
-  dev env and an in memory node in the test env.
-* Let `mount` know to start the Crux node by `require`-ing `<<project-ns>>.db.core` in some other namespace.
-* Restart the application.

--- a/resources/leiningen/new/luminus/db/docs/xtdb_instructions.md
+++ b/resources/leiningen/new/luminus/db/docs/xtdb_instructions.md
@@ -1,0 +1,6 @@
+#### XTDB configuration
+
+* XTDB can be configured in the `dev-config.edn` and `test-config.edn` files. By default you will have a local XTDB node in the
+  dev env and an in memory node in the test env.
+* Let `mount` know to start the XTDB node by `require`-ing `<<project-ns>>.db.core` in some other namespace.
+* Restart the application.

--- a/resources/leiningen/new/luminus/db/test/db/xtdb_test.clj
+++ b/resources/leiningen/new/luminus/db/test/db/xtdb_test.clj
@@ -1,7 +1,7 @@
 (ns <<project-ns>>.db.core-test
   (:require
     [<<project-ns>>.db.core :as db]
-    [crux.api :as crux]
+    [xtdb.api :as xt]
     [clojure.test :refer :all]
     [mount.core :as mount]))
 
@@ -24,16 +24,16 @@
   (let [{:keys [user/id]} (db/create-user! db/node user-1)]
     (is (uuid? id))
     (is (= (assoc user-1 :user/id id
-                         :crux.db/id id
+                         :xt/id id
                          :<<project-ns>>/type :user)
-           (crux/entity (crux/db db/node) id)))))
+           (xt/entity (xt/db db/node) id)))))
 
 (deftest update-user
   (let [{:keys [user/id]} (db/create-user! db/node user-1)]
     (db/update-user! db/node (assoc user-1 :user/id id
                                            :user/email "updated@test.com"))
     (is (= "updated@test.com"
-           (-> (crux/entity (crux/db db/node) id)
+           (-> (xt/entity (xt/db db/node) id)
                :user/email)))))
 
 (deftest find-user-by-id

--- a/src/leiningen/new/db.clj
+++ b/src/leiningen/new/db.clj
@@ -7,7 +7,7 @@
     (some #{"+mysql"} features) :mysql
     (some #{"+mongodb"} features) :mongo
     (some #{"+datomic"} features) :datomic
-    (some #{"+crux"} features) :crux
+    (some #{"+xtdb"} features) :xtdb
     (some #{"+h2"} features) :h2
     (some #{"+sqlite"} features) :sqlite))
 
@@ -61,9 +61,9 @@
   [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/datomic.clj"]
    ["{{resource-path}}/migrations/schema.edn" "db/migrations/schema.edn"]])
 
-(def crux-files
-  [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/crux.clj"]
-   ["{{backend-test-path}}/{{sanitized}}/db/core_test.clj" "db/test/db/crux_test.clj"]])
+(def xtdb-files
+  [["{{db-path}}/{{sanitized}}/db/core.clj" "db/src/xtdb.clj"]
+   ["{{backend-test-path}}/{{sanitized}}/db/core_test.clj" "db/test/db/xtdb_test.clj"]])
 
 (defn add-mongo [[assets options]]
   [(into assets mongo-files)
@@ -94,24 +94,24 @@
                                         ['com.google.guava/guava "25.1-jre"]
                                         ['io.rkn/conformity "0.5.1"]])))])
 
-(defn add-crux [[assets options]]
-  [(into assets crux-files)
+(defn add-xtdb [[assets options]]
+  [(into assets xtdb-files)
    (-> options
        (assoc
-         :crux true
+         :xtdb true
          :db-connection true
-         :db-docs ((:selmer-renderer options) (slurp-resource "db/docs/crux_instructions.md") options)
-         :database-profile-dev (str :crux-config "\n"
+         :db-docs ((:selmer-renderer options) (slurp-resource "db/docs/xtdb_instructions.md") options)
+         :database-profile-dev (str :xtdb-config "\n"
                                     (with-out-str (clojure.pprint/pprint
-                                                    {:crux/index-store {:kv-store {:crux/module 'crux.rocksdb/->kv-store
+                                                    {:xtdb/index-store {:kv-store {:xtdb/module 'xtdb.rocksdb/->kv-store
                                                                                    :db-dir "data/indices"}}
-                                                     :crux/document-store {:kv-store {:crux/module 'crux.rocksdb/->kv-store
+                                                     :xtdb/document-store {:kv-store {:xtdb/module 'xtdb.rocksdb/->kv-store
                                                                                       :db-dir "data/docs"}}
-                                                     :crux/tx-log {:kv-store {:crux/module 'crux.rocksdb/->kv-store
+                                                     :xtdb/tx-log {:kv-store {:xtdb/module 'xtdb.rocksdb/->kv-store
                                                                               :db-dir "data/transactions"}}})))
-         :database-profile-test (str :crux-config " " {}))
-       (append-options :dependencies [['juxt/crux-core "21.04-1.16.0-beta"]
-                                      ['juxt/crux-rocksdb "21.04-1.16.0-beta"]]))])
+         :database-profile-test (str :xtdb-config " " {}))
+       (append-options :dependencies [['com.xtdb/xtdb-core "1.19.0-beta1"]
+                                      ['com.xtdb/xtdb-rocksdb "1.19.0-beta1"]]))])
 
 (defn add-relational-db [db [assets options]]
   [(into assets (relational-db-files options))
@@ -136,6 +136,6 @@
     (cond
       (= :mongo db) (add-mongo state)
       (= :datomic db) (add-datomic state)
-      (= :crux db) (add-crux state)
+      (= :xtdb db) (add-xtdb state)
       :else (add-relational-db db state))
     state))

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -265,7 +265,7 @@
         supported-features #{;; routing
                              "+reitit"
                              ;;databases
-                             "+sqlite" "+h2" "+postgres" "+mysql" "+mongodb" "+datomic" "+crux"
+                             "+sqlite" "+h2" "+postgres" "+mysql" "+mongodb" "+datomic" "+xtdb"
                              ;;servers
                              "+aleph" "+jetty" "+http-kit" "+immutant" "+undertow"
                              ;;misc


### PR DESCRIPTION
Hi Dmitri, here's a bit of renaming following the recent crux -> XTDB rename.

Considered leaving the old `+crux`option as well for backwards compatibility but decided against it. Happy to do that though if you think it make sense.

I also noticed that we were missing the +crux option in the readme - think I might have left that out last time as I wasn't sure about the luminusdiff link. Would you be able to add that in please if/when it's released? Thanks!