### PR TITLE
Support for async ring handlers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## 4.45
+- async support: 1 and 3 argument ring handlers for all middleware
+- fixes +servlet feature - the middleware did not chain to the next handler
+- ring-undertow-adapter: 1.2.8  for async support
+- lein-uberwar: 0.2.3 for async support
+- ring-core 1.9.6
+- ring-devel 1.9.6
+- ring-defaults 0.3.4
+
 ## 4.44
 - formatting
   

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,21 @@
 - async support: 1 and 3 argument ring handlers for all middleware
 - fixes +servlet feature - the middleware did not chain to the next handler
 - ring-undertow-adapter: 1.2.8  for async support
+- funcool/promesa 9.0.471 for async support
 - lein-uberwar: 0.2.3 for async support
 - ring-core 1.9.6
 - ring-devel 1.9.6
 - ring-defaults 0.3.4
+- logback-classic 1.4.4
+- clojure.java-time 1.1.0
+- markdown-clj 1.11.3
+- nrepl 1.0.0
+- org.clojure/tools.cli 1.0.2014
+- org.webjars.npm/material-icons 1.10.8
+- selmer 1.12.55
+- thheller/shadow-cljs 2.20.3
+- com.google.javascript/closure-compiler-unshaded kept at v20220803 - v20221004 breaks shadow-cljs
+
 
 ## 4.44
 - formatting

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 4.45
+## 4.46
 - async support: 1 and 3 argument ring handlers for all middleware
 - fixes +servlet feature - the middleware did not chain to the next handler
 - ring-undertow-adapter: 1.2.8  for async support
@@ -18,7 +18,7 @@
 - com.google.javascript/closure-compiler-unshaded kept at v20220803 - v20221004 breaks shadow-cljs
 
 
-## 4.44
+## 4.45
 - formatting
   
 ## 4.44

--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ ab -c 10 -n 1000 http://127.0.0.1:3000/
 
 The memory and CPU usage can be inspected by running either `jconsole` or `jvisualvm` and attaching them to a running Luminus server.
 
+## Async Ring Handlers
+
+Using async ring handlers is possible, but 
+you'll see a blank screen, at worst without error messages.
+
+The server (undertow, jetty, ...) and every middleware used has to support async request handling.
+
+To enable: add `:async? true` to your config maps.
+
+Tested combinations:
+
+* default: needs luminus/ring-undertow-adapter 1.2.8-SNAPSHOT
+* +war: needs luminus/ring-undertow-adapter 1.2.8-SNAPSHOT
+* +servlet +war (this implies jetty9)
+
 ## Other Templates
 
 * [chestnut](https://github.com/plexus/chestnut)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ However, if you would like to attach further functionality to your template you 
 | +kibit       | misc          | adds [lein-kibit](https://github.com/jonase/kibit) plugin                                                                                                       | [diff](https://github.com/nfedyashev/luminusdiff/compare/3.85..3.85+kibit)       |
 | +servlet     | misc          | adds middleware for handling Servlet context                                                                                                                    | [diff](https://github.com/nfedyashev/luminusdiff/compare/3.85..3.85+servlet)     |
 | +basic       | misc          | generates a bare bones luminus project                                                                                                                          | [diff](https://github.com/nfedyashev/luminusdiff/compare/3.85..3.85+basic)       |
+| +async       | misc          | support for async (= 3 argument) ring handlers                                                                                                                  |        |
 
 
 To add a profile simply pass it as an argument after your application name, e.g.:
@@ -121,7 +122,6 @@ Tested combinations:
 * +jetty: works
 * +http-kit: the template works, but http-kit does not support async handlers
 * +aleph: the template works, but aleph does not seem to support async handlers
-
 
 ## Other Templates
 

--- a/README.md
+++ b/README.md
@@ -103,18 +103,25 @@ The memory and CPU usage can be inspected by running either `jconsole` or `jvisu
 
 ## Async Ring Handlers
 
-Using async ring handlers is possible, but 
-you'll see a blank screen, at worst without error messages.
+Using async ring handlers is possible but adds another layer of
+complexity.  If things go wrong you'll see a blank screen, possibly
+without any error message.
 
-The server (undertow, jetty, ...) and every middleware used has to support async request handling.
+The server (undertow, jetty, servlet) and every middleware in the chain has to 
+support async request handling.
 
 To enable: add `:async? true` to your config maps.
 
 Tested combinations:
 
-* default: needs luminus/ring-undertow-adapter 1.2.8-SNAPSHOT
-* +war: needs luminus/ring-undertow-adapter 1.2.8-SNAPSHOT
-* +servlet +war (this implies jetty9)
+* default
+* +war
+* +servlet +war (this implies jetty9): http://localhost:3000/your-ns instead of just /
+* +jetty +war: http://localhost:3000/your-ns instead of just /
+* +jetty: works
+* +http-kit: the template works, but http-kit does not support async handlers
+* +aleph: the template works, but aleph does not seem to support async handlers
+
 
 ## Other Templates
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.5.3"
   :eval-in-leiningen true
   :dependencies [[leinjacker "0.4.3"]
-                 [selmer "1.12.31"]]
+                 [selmer "1.12.55"]]
   :plugins [[lein-cljfmt "0.6.4"]
             [commons-io/commons-io "2.6"]])
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/lein-template "4.45"
+(defproject luminus/lein-template "4.46-SNAPSHOT"
   :description "a template for creating Luminus applications"
   :url "https://github.com/yogthos/luminus-template"
   :license {:name "MIT License"

--- a/resources/leiningen/new/luminus/core/dev-config.edn
+++ b/resources/leiningen/new/luminus/core/dev-config.edn
@@ -6,7 +6,8 @@
  :port 3000
  ;; when :nrepl-port is set the application starts the nREPL server on load
  :nrepl-port 7000
- <% if oauth %>
+ <% if async %>:async? true
+ <% endif %><% if oauth %>
  ;;Twitter used as an example, replace these URIs with the OAuth provider of your choice
  :request-token-uri "https://api.twitter.com/oauth/request_token"
  :access-token-uri "https://api.twitter.com/oauth/access_token"

--- a/resources/leiningen/new/luminus/core/env/dev/clj/dev_middleware.clj
+++ b/resources/leiningen/new/luminus/core/env/dev/clj/dev_middleware.clj
@@ -1,5 +1,6 @@
 (ns <<project-ns>>.dev-middleware
   (:require
+    [<<project-ns>>.config :refer [env]]
     [ring.middleware.reload :refer [wrap-reload]]
     [selmer.middleware :refer [wrap-error-page]]
     [prone.middleware :refer [wrap-exceptions]]))
@@ -8,4 +9,5 @@
   (-> handler
       wrap-reload
       wrap-error-page
-      (wrap-exceptions {:app-namespaces ['<<project-ns>>]})))
+      ;; disable prone middleware, it can not handle async
+      (cond-> (not (env :async?)) (wrap-exceptions {:app-namespaces ['<<project-ns>>]}))))

--- a/resources/leiningen/new/luminus/core/env/dev/resources/config.edn
+++ b/resources/leiningen/new/luminus/core/env/dev/resources/config.edn
@@ -1,1 +1,1 @@
-{}
+{<% if async %>:async? true<% endif %>}

--- a/resources/leiningen/new/luminus/core/env/prod/resources/config.edn
+++ b/resources/leiningen/new/luminus/core/env/prod/resources/config.edn
@@ -1,2 +1,4 @@
 {:prod true
- :port 3000}
+ :port 3000<% if async %>
+ :async? true
+ <% endif %>}

--- a/resources/leiningen/new/luminus/core/gitignore
+++ b/resources/leiningen/new/luminus/core/gitignore
@@ -11,6 +11,9 @@ test-config.edn
 profiles.clj
 /.env
 .nrepl-port
+/.clj-kondo/.cache/
+/.lsp/.cache/
+/.calva/output-window/
 <% if shadow-cljs %>/.shadow-cljs<% endif %>
 /node_modules
 /log

--- a/resources/leiningen/new/luminus/core/src/core.clj
+++ b/resources/leiningen/new/luminus/core/src/core.clj
@@ -29,7 +29,7 @@
         (update :io-threads #(or % (* 2 (.availableProcessors (Runtime/getRuntime))))) <% endif %>
         (assoc  :handler (handler/app))
         (update :port #(or (-> env :options :port) %))
-        (select-keys [:handler :host :port])))
+        (select-keys [:handler :host :port :async?])))
   :stop
   (http/stop http-server))
 

--- a/resources/leiningen/new/luminus/core/test-config.edn
+++ b/resources/leiningen/new/luminus/core/test-config.edn
@@ -3,4 +3,5 @@
 ;; This file is listed in .gitignore and will be excluded from version control by Git.
 
 {:port 3000
- <% if database-profile-dev %><<database-profile-test>><% endif %>}
+ <% if async %>:async true
+ <% endif %><% if database-profile-dev %><<database-profile-test>><% endif %>}

--- a/resources/leiningen/new/luminus/reitit/src/handler-fragment.clj
+++ b/resources/leiningen/new/luminus/reitit/src/handler-fragment.clj
@@ -1,3 +1,7 @@
+(defn- async-aware-default-handler
+  ([_] nil)
+  ([_ respond _] (respond nil)))
+
 <% if service %>
 (mount/defstate app-routes
   :start
@@ -10,7 +14,7 @@
     (ring/routes
       (ring/create-resource-handler
         {:path "/"})<% if expanded %>
-      (wrap-content-type (wrap-webjars (constantly nil)))<% endif %>
+      (wrap-content-type (wrap-webjars async-aware-default-handler))<% endif %>
       (ring/create-default-handler))))
 <% else %>
 (mount/defstate app-routes
@@ -28,7 +32,7 @@
       (ring/create-resource-handler
         {:path "/"})<% if expanded %>
       (wrap-content-type
-        (wrap-webjars (constantly nil)))<% endif %>
+        (wrap-webjars async-aware-default-handler))<% endif %>
       (ring/create-default-handler
         {:not-found
          (constantly (error-page {:status 404, :title "404 - Page not found"}))

--- a/resources/leiningen/new/luminus/reitit/src/home.clj
+++ b/resources/leiningen/new/luminus/reitit/src/home.clj
@@ -13,7 +13,9 @@
 (defn home-routes []
   [<% if war %>"/<<name>>"<% else %>""<% endif %>
    {:middleware [middleware/wrap-csrf
-                 middleware/wrap-formats]}
+                 middleware/wrap-formats
+                 ;; wrap-as-async must be last
+                 middleware/wrap-as-async]}
    ["/" {:get home-page}]<% if graphql %>
    ["/graphiql" {:get (fn [request] (layout/render request "graphiql.html"))}]<% endif %><% if expanded %>
    ["/docs" {:get (fn [_]
@@ -29,7 +31,9 @@
 (defn home-routes []
   [<% if war %> "/<<name>>" <% else %> "" <% endif %>
    {:middleware [middleware/wrap-csrf
-                 middleware/wrap-formats]}
+                 middleware/wrap-formats
+                 ;; wrap-as-async must be last
+                 middleware/wrap-as-async]}
    ["/" {:get home-page}]<% if graphql %>
    ["/graphiql" {:get (fn [request]
                         (layout/render request "graphiql.html"))}]<% endif %><% if expanded %>

--- a/resources/leiningen/new/luminus/reitit/src/home.clj
+++ b/resources/leiningen/new/luminus/reitit/src/home.clj
@@ -5,7 +5,18 @@
    [clojure.java.io :as io]
    [<<project-ns>>.middleware :as middleware]
    [ring.util.response]
-   [ring.util.http-response :as response]))
+   [ring.util.http-response :as response]<% if async %>
+   [promesa.core :as p]<% endif %>))
+<% if async %>
+(defn expensive [_]
+  (p/delay 5000 {:status 200
+                  :headers {"content-type" "text/plain"}
+                  :body "Imagine this was a long running request.
+
+But is uses promesa/CompletableFuture under the covers, so it does not tie
+up a thread - it is async."}))
+<% endif %>
+
 <% if cljs  %>
 (defn home-page [request]
   (layout/render request "home.html"))
@@ -13,11 +24,12 @@
 (defn home-routes []
   [<% if war %>"/<<name>>"<% else %>""<% endif %>
    {:middleware [middleware/wrap-csrf
-                 middleware/wrap-formats
+                 middleware/wrap-formats<% if async %>
                  ;; wrap-as-async must be last
-                 middleware/wrap-as-async]}
+                 middleware/wrap-as-async<% endif %>]}
    ["/" {:get home-page}]<% if graphql %>
-   ["/graphiql" {:get (fn [request] (layout/render request "graphiql.html"))}]<% endif %><% if expanded %>
+   ["/graphiql" {:get (fn [request] (layout/render request "graphiql.html"))}]<% endif %><% if async %>
+   ["/expensive" {:get expensive}]<% endif %><% if expanded %>
    ["/docs" {:get (fn [_]
                     (-> (response/ok (-> "docs/docs.md" io/resource slurp))
                         (response/header "Content-Type" "text/plain; charset=utf-8")))}]<% endif %>])
@@ -32,9 +44,10 @@
   [<% if war %> "/<<name>>" <% else %> "" <% endif %>
    {:middleware [middleware/wrap-csrf
                  middleware/wrap-formats
-                 ;; wrap-as-async must be last
-                 middleware/wrap-as-async]}
-   ["/" {:get home-page}]<% if graphql %>
+                 <% if async %>;; wrap-as-async must be last
+                 middleware/wrap-as-async<% endif %>]}
+   ["/" {:get home-page}]<% if async %>
+   ["/expensive" {:get expensive}]<% endif %><% if graphql %>
    ["/graphiql" {:get (fn [request]
                         (layout/render request "graphiql.html"))}]<% endif %><% if expanded %>
    ["/about" {:get about-page}]<% endif %>])

--- a/src/leiningen/new/async.clj
+++ b/src/leiningen/new/async.clj
@@ -1,0 +1,13 @@
+(ns leiningen.new.async
+  (:require [leiningen.new.common :refer :all]))
+
+(def async-dependencies
+  [['funcool/promesa "9.0.470"]])
+
+(defn async-features [[assets options :as state]]
+  (if (some #{"+async"} (:features options))
+    [assets
+     (-> options
+         (assoc :async true)
+         (append-options :dependencies async-dependencies))]
+    state))

--- a/src/leiningen/new/async.clj
+++ b/src/leiningen/new/async.clj
@@ -2,7 +2,7 @@
   (:require [leiningen.new.common :refer :all]))
 
 (def async-dependencies
-  [['funcool/promesa "9.0.470"]])
+  [['funcool/promesa "9.0.471"]])
 
 (defn async-features [[assets options :as state]]
   (if (some #{"+async"} (:features options))

--- a/src/leiningen/new/expanded.clj
+++ b/src/leiningen/new/expanded.clj
@@ -2,11 +2,11 @@
   (:require [leiningen.new.common :refer :all]))
 
 (def expanded-dependencies
-  [['markdown-clj "1.11.2"]
+  [['markdown-clj "1.11.3"]
    ['funcool/struct "1.4.0"]
    #_['funcool/cuerdas "2021.05.29-0"]
    ['org.webjars.npm/bulma "0.9.4"]
-   ['org.webjars.npm/material-icons "1.0.0"]
+   ['org.webjars.npm/material-icons "1.10.8"]
    ['ring-webjars "0.2.0"]
    ['org.webjars/webjars-locator "0.45"]])
 

--- a/src/leiningen/new/logback.clj
+++ b/src/leiningen/new/logback.clj
@@ -7,7 +7,7 @@
    ["env/prod/resources/logback.xml" "core/env/prod/resources/logback.xml"]])
 
 (def logback-dependencies
-  [['ch.qos.logback/logback-classic "1.2.11"]])
+  [['ch.qos.logback/logback-classic "1.4.4"]])
 
 (defn logback-features [[assets options :as state]]
   (if (some #{"+logback"} (:features options))

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -129,8 +129,8 @@
    ['metosin/muuntaja "0.6.8"]
    ['metosin/ring-http-response "0.9.3"]
    ['org.clojure/tools.logging "1.2.4"]
-   ['ring/ring-core "1.9.5"]
-   ['ring/ring-defaults "0.3.3"]
+   ['ring/ring-core "1.9.6"]
+   ['ring/ring-defaults "0.3.4"]
    ['luminus/ring-ttl-session "0.3.3"]
    ['mount "0.1.16"]
    ['cprop "0.1.19"]
@@ -141,7 +141,7 @@
 (def core-dev-dependencies
   [['prone "2021-04-23"]
    ['ring/ring-mock "0.4.0"]
-   ['ring/ring-devel "1.9.5"]
+   ['ring/ring-devel "1.9.6"]
    ['org.clojure/tools.namespace "1.3.0"]
    ['pjstadig/humane-test-output "0.11.0"]])
 

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -123,9 +123,9 @@
 
 (def core-dependencies
   [['org.clojure/clojure "1.11.1"]
-   ['selmer "1.12.53"]
+   ['selmer "1.12.55"]
    ['json-html "0.4.7"]
-   ['clojure.java-time "0.3.3"]
+   ['clojure.java-time "1.1.0"]
    ['luminus-transit "0.1.5"]
    ['metosin/muuntaja "0.6.8"]
    ['metosin/ring-http-response "0.9.3"]
@@ -135,8 +135,8 @@
    ['luminus/ring-ttl-session "0.3.3"]
    ['mount "0.1.16"]
    ['cprop "0.1.19"]
-   ['org.clojure/tools.cli "1.0.206"]
-   ['nrepl "0.9.0"]
+   ['org.clojure/tools.cli "1.0.214"]
+   ['nrepl "1.0.0"]
    ['expound "0.9.0"]])
 
 (def core-dev-dependencies

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -38,7 +38,8 @@
             [leiningen.new.oauth :refer [oauth-features]]
             [leiningen.new.calva :refer [calva-features]]
             [leiningen.new.expanded :refer [expanded-features]]
-            [leiningen.new.undertow :refer [undertow-features]]))
+            [leiningen.new.undertow :refer [undertow-features]]
+            [leiningen.new.async :refer [async-features]]))
 
 (defn resource [r]
   (->> r (str "leiningen/new/luminus/core/resources/") (io/resource)))
@@ -188,7 +189,8 @@
             logback-features
             oauth-features
             war-features
-            calva-features)]
+            calva-features
+            async-features)]
     (render-assets assets binary-assets (format-options options))))
 
 (defn format-features [features]
@@ -274,7 +276,8 @@
                              "+swagger" "+war" "+graphql"
                              "+kibit" "+service" "+servlet"
                              "+boot" "+shadow-cljs" "+ctmx"
-                             "+basic" "+expanded"}
+                             "+basic" "+expanded"
+                             "+async"}
         options            (merge
                              project-relative-paths
                              {:name             (project-name name)

--- a/src/leiningen/new/shadow_cljs.clj
+++ b/src/leiningen/new/shadow_cljs.clj
@@ -1,7 +1,7 @@
 (ns leiningen.new.shadow-cljs
   (:require [leiningen.new.common :refer :all]))
 
-(def shadow-version "2.19.9")
+(def shadow-version "2.20.3")
 
 (def shadow-cljs-dependencies [['thheller/shadow-cljs shadow-version :scope "provided"]
                                ['com.google.javascript/closure-compiler-unshaded "v20220803"]

--- a/src/leiningen/new/undertow.clj
+++ b/src/leiningen/new/undertow.clj
@@ -9,5 +9,6 @@
            :undertow-based true
            :server "undertow")
          (update :dependencies conj ['org.webjars/webjars-locator-jboss-vfs "0.1.0"])
-         (append-options :http-server-dependencies [['luminus-undertow "0.1.15"]]))]
+         (append-options :http-server-dependencies [['luminus-undertow "0.1.15"]
+                                                    ['luminus/ring-undertow-adapter "1.2.8-SNAPSHOT"]]))]
     state))

--- a/src/leiningen/new/undertow.clj
+++ b/src/leiningen/new/undertow.clj
@@ -9,6 +9,5 @@
            :undertow-based true
            :server "undertow")
          (update :dependencies conj ['org.webjars/webjars-locator-jboss-vfs "0.1.0"])
-         (append-options :http-server-dependencies [['luminus-undertow "0.1.15"]
-                                                    ['luminus/ring-undertow-adapter "1.2.8"]]))]
+         (append-options :http-server-dependencies [['luminus-undertow "0.1.16"]]))]
     state))

--- a/src/leiningen/new/undertow.clj
+++ b/src/leiningen/new/undertow.clj
@@ -10,5 +10,5 @@
            :server "undertow")
          (update :dependencies conj ['org.webjars/webjars-locator-jboss-vfs "0.1.0"])
          (append-options :http-server-dependencies [['luminus-undertow "0.1.15"]
-                                                    ['luminus/ring-undertow-adapter "1.2.8-SNAPSHOT"]]))]
+                                                    ['luminus/ring-undertow-adapter "1.2.8"]]))]
     state))

--- a/src/leiningen/new/war.clj
+++ b/src/leiningen/new/war.clj
@@ -2,13 +2,17 @@
   (:require [leiningen.new.common :refer :all]
             [clojure.set :refer [rename-keys]]))
 
-(defn ring-options [{:keys [name project-ns]}]
-  {:handler      (symbol (str project-ns ".handler/app-handler"))
-   :init         (symbol (str project-ns ".handler/init"))
-   :destroy      (symbol (str project-ns ".handler/destroy"))
-   :servlet-version "3.1"
-   :async?       true
-   :name (str name ".war")})
+(defn ring-options [{:keys [name project-ns] :as options}]
+  (let [opts {:handler      (symbol (str project-ns ".handler/app-handler"))
+              :init         (symbol (str project-ns ".handler/init"))
+              :destroy      (symbol (str project-ns ".handler/destroy"))
+              :name (str name ".war")}]
+    ;; put it in war, put it in async, put it in a third place?
+    (if (some #{"+async"} (:features options))
+      (assoc opts
+             :servlet-version "3.1"
+             :async?       true)
+      opts)))
 
 (defn update-assets [assets]
   (map

--- a/src/leiningen/new/war.clj
+++ b/src/leiningen/new/war.clj
@@ -6,6 +6,8 @@
   {:handler      (symbol (str project-ns ".handler/app-handler"))
    :init         (symbol (str project-ns ".handler/init"))
    :destroy      (symbol (str project-ns ".handler/destroy"))
+   :servlet-version "3.1"
+   :async?       true
    :name (str name ".war")})
 
 (defn update-assets [assets]
@@ -26,9 +28,9 @@
                                  (if (some #{['luminus/ring-ttl-session "0.3.3"]} dependencies)
                                    dependencies
                                    (conj dependencies ['luminus/ring-ttl-session "0.3.3"]))))
-         (append-options :dependencies [['ring/ring-servlet "1.7.1"]])
+         (append-options :dependencies [['ring/ring-servlet "1.9.6"]])
          (append-options :dev-dependencies (into [['directory-naming/naming-java "0.8"]]
                                                  (:http-server-dependencies options)))
          (append-options :plugins (if (some #{"+lein"} (:features options))
-                                    [['lein-uberwar "0.2.1"]])))]
+                                    [['lein-uberwar "0.2.3"]])))]
     state))


### PR DESCRIPTION
closes #571

There is an async feature now that switches the server into async mode.  It also provides a utility middleware to make async handlers less painful, plus an example.

The general purpose middleware can all handle 1 and 3 arguments now, this is not tied to any feature.

I also pulled in funcool/promesa for the feature.  Programming with callbacks is not fun, promesa is fun AND cool.  It says so in the name, right?

While testing I also ran lein ancient a bunch, and I bumped whatever was outdated.

The selmer bump seems to have accidentally fixed #572