### PR TITLE
Fix asset path name to material fonts

### DIFF
--- a/resources/leiningen/new/luminus/expanded/resources/css/screen.css
+++ b/resources/leiningen/new/luminus/expanded/resources/css/screen.css
@@ -6,12 +6,10 @@ body {
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(/assets/material-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(/assets/material-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
-       url(/assets/material-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
-       url(/assets/material-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+       url(/assets/material-icons/iconfont/material-icons.woff2) format('woff2'),
+       url(/assets/material-icons/iconfont/material-icons.woff) format('woff');
 }
 .material-icons {
   font-family: 'Material Icons';


### PR DESCRIPTION
The [material icons](https://github.com/marella/material-icons) changed the names of the icon files in version 0.7.0 (see the [release notes](https://github.com/marella/material-icons/releases/tag/v0.7.0)). 
- The `eot` and the `ttf` font files were removed
-  The `woff2` and `woff` font files were renamed (`MaterialIconsOutlined-Regular` → `material-icons-outlined`)

Since Luminus depends on material-icons version 1.10.8 I think it is safe to change the css.